### PR TITLE
Add students module and exclude frontend-only roles from user admin

### DIFF
--- a/modules/Students/Http/Controllers/StudentController.php
+++ b/modules/Students/Http/Controllers/StudentController.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Modules\Students\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Modules\Students\Http\Requests\StoreStudentRequest;
+use Modules\Students\Http\Requests\UpdateStudentRequest;
+
+class StudentController extends Controller
+{
+    /**
+     * Display a listing of students.
+     */
+    public function index(Request $request)
+    {
+        $filters = $this->filters($request);
+        $students = $this->filteredStudents($filters);
+
+        $stats = [
+            'total' => $this->studentsQuery()->count(),
+            'active' => $this->studentsQuery()->where('active', true)->count(),
+            'inactive' => $this->studentsQuery()->where('active', false)->count(),
+        ];
+
+        return view('students::index', compact('students', 'filters', 'stats'));
+    }
+
+    /**
+     * Show the form for creating a new student.
+     */
+    public function create()
+    {
+        return view('students::create');
+    }
+
+    /**
+     * Store a newly created student in storage.
+     */
+    public function store(StoreStudentRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $avatarPath = $this->handleAvatarUpload($request);
+
+        $student = User::create([
+            'name' => $data['name'],
+            'username' => $data['username'],
+            'email' => $data['email'],
+            'phone' => $data['phone'] ?? null,
+            'password' => Hash::make($data['password']),
+            'avatar' => $avatarPath,
+            'active' => $request->boolean('active', true),
+        ]);
+
+        $student->syncRoles(['student']);
+
+        return redirect()
+            ->route('students.show', $student)
+            ->with('success', 'تم إضافة الطالب بنجاح.');
+    }
+
+    /**
+     * Display the specified student.
+     */
+    public function show(User $student)
+    {
+        $student->load('roles', 'permissions');
+
+        $assignedRole = $student->roles->first();
+        $rolePermissions = $assignedRole?->permissions()->pluck('display_name', 'name') ?? collect();
+        $activityCount = method_exists($student, 'activities') ? $student->activities()->count() : 0;
+
+        return view('students::show', [
+            'student' => $student,
+            'rolePermissions' => $rolePermissions,
+            'activityCount' => $activityCount,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified student.
+     */
+    public function edit(User $student)
+    {
+        return view('students::edit', compact('student'));
+    }
+
+    /**
+     * Update the specified student in storage.
+     */
+    public function update(UpdateStudentRequest $request, User $student): RedirectResponse
+    {
+        $data = $request->validated();
+        $payload = [
+            'name' => $data['name'],
+            'username' => $data['username'],
+            'email' => $data['email'],
+            'phone' => $data['phone'] ?? null,
+            'active' => $request->boolean('active'),
+        ];
+
+        if (! empty($data['password'])) {
+            $payload['password'] = Hash::make($data['password']);
+        }
+
+        $avatarPath = $this->handleAvatarUpload($request, $student);
+        if ($avatarPath !== null) {
+            $payload['avatar'] = $avatarPath;
+        }
+
+        $student->update($payload);
+        $student->syncRoles(['student']);
+
+        return redirect()
+            ->route('students.show', $student)
+            ->with('success', 'تم تحديث بيانات الطالب بنجاح.');
+    }
+
+    /**
+     * Remove the specified student from storage.
+     */
+    public function destroy(User $student): RedirectResponse
+    {
+        $this->deleteAvatarIfExists($student);
+        $student->delete();
+
+        return redirect()
+            ->route('students.index')
+            ->with('success', 'تم حذف الطالب بنجاح.');
+    }
+
+    /**
+     * Toggle the activation status of the given student.
+     */
+    public function toggleStatus(User $student): RedirectResponse
+    {
+        $student->update(['active' => ! $student->active]);
+
+        return redirect()
+            ->back()
+            ->with('success', $student->active ? 'تم تفعيل الطالب.' : 'تم إيقاف الطالب.');
+    }
+
+    /**
+     * Reset the password of the given student.
+     */
+    public function resetPassword(User $student): RedirectResponse
+    {
+        $plainPassword = Str::random(12);
+        $student->forceFill([
+            'password' => Hash::make($plainPassword),
+        ])->save();
+
+        return redirect()
+            ->back()
+            ->with('info', 'تم إعادة تعيين كلمة المرور للطالب. كلمة المرور الجديدة: ' . $plainPassword);
+    }
+
+    /**
+     * Display simple reports for students.
+     */
+    public function reports()
+    {
+        $statistics = [
+            'total' => $this->studentsQuery()->count(),
+            'active' => $this->studentsQuery()->where('active', true)->count(),
+            'inactive' => $this->studentsQuery()->where('active', false)->count(),
+        ];
+
+        $recentStudents = $this->studentsQuery()
+            ->latest()
+            ->take(8)
+            ->get();
+
+        return view('students::reports', compact('statistics', 'recentStudents'));
+    }
+
+    /**
+     * Retrieve the base query for students handled within the module.
+     */
+    protected function studentsQuery(): Builder
+    {
+        return User::query()->whereHas('roles', fn ($query) => $query->where('name', 'student'));
+    }
+
+    /**
+     * Retrieve filtered students for the index page.
+     */
+    protected function filteredStudents(array $filters): LengthAwarePaginator
+    {
+        $query = $this->studentsQuery()->with('roles');
+
+        if (! empty($filters['search'])) {
+            $search = $filters['search'];
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%")
+                    ->orWhere('username', 'like', "%{$search}%")
+                    ->orWhere('phone', 'like', "%{$search}%");
+            });
+        }
+
+        if ($filters['status'] !== null) {
+            $query->where('active', (bool) $filters['status']);
+        }
+
+        return $query
+            ->orderBy('name')
+            ->paginate(12)
+            ->withQueryString();
+    }
+
+    /**
+     * Extract filters from the request.
+     */
+    protected function filters(Request $request): array
+    {
+        $status = $request->input('status');
+        $status = $status === 'active' ? 1 : ($status === 'inactive' ? 0 : null);
+
+        return [
+            'search' => $request->input('search'),
+            'status' => $status,
+        ];
+    }
+
+    /**
+     * Handle avatar upload for store/update operations.
+     */
+    protected function handleAvatarUpload(Request $request, ?User $student = null): ?string
+    {
+        if (! $request->hasFile('avatar')) {
+            return $student?->avatar;
+        }
+
+        $avatar = $request->file('avatar');
+        $path = $avatar->store('avatars', 'public');
+
+        if ($student && $student->avatar) {
+            Storage::disk('public')->delete($student->avatar);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Delete stored avatar if it exists.
+     */
+    protected function deleteAvatarIfExists(User $student): void
+    {
+        if ($student->avatar) {
+            Storage::disk('public')->delete($student->avatar);
+        }
+    }
+}

--- a/modules/Students/Http/Requests/StoreStudentRequest.php
+++ b/modules/Students/Http/Requests/StoreStudentRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Modules\Students\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreStudentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create_students') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:255', 'unique:users,username'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'active' => ['nullable', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
+        ];
+    }
+
+    /**
+     * Customize validation attributes.
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => 'اسم الطالب',
+            'username' => 'اسم الدخول',
+            'email' => 'البريد الإلكتروني',
+            'phone' => 'رقم الهاتف',
+            'password' => 'كلمة المرور',
+            'avatar' => 'صورة الطالب',
+        ];
+    }
+}

--- a/modules/Students/Http/Requests/UpdateStudentRequest.php
+++ b/modules/Students/Http/Requests/UpdateStudentRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Modules\Students\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateStudentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('edit_students') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        $studentId = $this->route('student')?->getKey();
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:255', 'unique:users,username,' . $studentId],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email,' . $studentId],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'active' => ['nullable', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
+        ];
+    }
+
+    /**
+     * Customize validation attributes.
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => 'اسم الطالب',
+            'username' => 'اسم الدخول',
+            'email' => 'البريد الإلكتروني',
+            'phone' => 'رقم الهاتف',
+            'password' => 'كلمة المرور',
+            'avatar' => 'صورة الطالب',
+        ];
+    }
+}

--- a/modules/Students/Providers/StudentServiceProvider.php
+++ b/modules/Students/Providers/StudentServiceProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\Students\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+
+class StudentServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $moduleBasePath = __DIR__ . '/../';
+
+        $this->loadRoutesFrom($moduleBasePath . 'Routes/web.php');
+        $this->loadViewsFrom($moduleBasePath . 'Resources/views', 'students');
+        $this->loadTranslationsFrom($moduleBasePath . 'Resources/lang', 'students');
+
+        $this->registerViewComponents();
+    }
+
+    /**
+     * Register reusable blade components used within the module.
+     */
+    protected function registerViewComponents(): void
+    {
+        $componentsPath = __DIR__ . '/../Resources/views/components';
+
+        if (! File::isDirectory($componentsPath)) {
+            return;
+        }
+
+        foreach (File::allFiles($componentsPath) as $component) {
+            $view = str_replace('.blade.php', '', $component->getRelativePathname());
+            $alias = 'students-' . str_replace(DIRECTORY_SEPARATOR, '-', $view);
+
+            Blade::component('students::components.' . str_replace(DIRECTORY_SEPARATOR, '.', $view), $alias);
+        }
+    }
+}

--- a/modules/Students/Resources/views/create.blade.php
+++ b/modules/Students/Resources/views/create.blade.php
@@ -1,0 +1,58 @@
+@extends('admin.layouts.master')
+
+@section('title', 'إضافة طالب جديد - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إضافة طالب جديد')
+    @section('page-subtitle', 'تعبئة بيانات الطالب وتفعيل حسابه')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">إضافة طالب</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="fas fa-user-plus me-2"></i> بيانات الطالب</h5>
+            <a href="{{ route('students.index') }}" class="btn btn-outline-secondary btn-sm">
+                <i class="fas fa-arrow-right"></i> العودة للقائمة
+            </a>
+        </div>
+        <div class="card-body">
+            <form action="{{ route('students.store') }}" method="POST" enctype="multipart/form-data" class="needs-validation" novalidate>
+                @csrf
+                @include('students::partials.form', ['student' => new \App\Models\User()])
+
+                <div class="mt-4 d-flex justify-content-end gap-2">
+                    <a href="{{ route('students.index') }}" class="btn btn-light">
+                        إلغاء
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save"></i> حفظ الطالب
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection
+
+@push('inline-scripts')
+<script>
+    (function () {
+        'use strict';
+        const forms = document.querySelectorAll('.needs-validation');
+        Array.from(forms).forEach(form => {
+            form.addEventListener('submit', event => {
+                if (!form.checkValidity()) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                form.classList.add('was-validated');
+            }, false);
+        });
+    })();
+</script>
+@endpush

--- a/modules/Students/Resources/views/edit.blade.php
+++ b/modules/Students/Resources/views/edit.blade.php
@@ -1,0 +1,59 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تعديل بيانات الطالب - ' . $student->name)
+
+@section('page-header')
+    @section('page-title', 'تعديل بيانات الطالب')
+    @section('page-subtitle', 'تحديث بيانات حساب الطالب وإدارته')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">{{ $student->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="fas fa-user-edit me-2"></i> بيانات الطالب</h5>
+            <a href="{{ route('students.show', $student) }}" class="btn btn-outline-secondary btn-sm">
+                <i class="fas fa-arrow-right"></i> عرض التفاصيل
+            </a>
+        </div>
+        <div class="card-body">
+            <form action="{{ route('students.update', $student) }}" method="POST" enctype="multipart/form-data" class="needs-validation" novalidate>
+                @csrf
+                @method('PUT')
+                @include('students::partials.form', ['student' => $student])
+
+                <div class="mt-4 d-flex justify-content-end gap-2">
+                    <a href="{{ route('students.show', $student) }}" class="btn btn-light">
+                        إلغاء
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save"></i> حفظ التعديلات
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection
+
+@push('inline-scripts')
+<script>
+    (function () {
+        'use strict';
+        const forms = document.querySelectorAll('.needs-validation');
+        Array.from(forms).forEach(form => {
+            form.addEventListener('submit', event => {
+                if (!form.checkValidity()) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                form.classList.add('was-validated');
+            }, false);
+        });
+    })();
+</script>
+@endpush

--- a/modules/Students/Resources/views/index.blade.php
+++ b/modules/Students/Resources/views/index.blade.php
@@ -1,0 +1,181 @@
+@extends('admin.layouts.master')
+
+@section('title', 'إدارة الطلاب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إدارة الطلاب')
+    @section('page-subtitle', 'متابعة حسابات الطلاب وتحديث بياناتهم')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item active">الطلاب</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-md-4">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon students"><i class="fas fa-user-graduate"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ $stats['total'] }}</div>
+                    <div class="stat-label">إجمالي الطلاب</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-check"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-success">{{ $stats['active'] }}</div>
+                    <div class="stat-label">طلاب نشطون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon teachers"><i class="fas fa-user-slash"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-danger">{{ $stats['inactive'] }}</div>
+                    <div class="stat-label">طلاب غير نشطين</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
+                <h5 class="mb-0"><i class="fas fa-filter me-2"></i> تصفية النتائج</h5>
+                @can('create_students')
+                    <a href="{{ route('students.create') }}" class="btn btn-primary">
+                        <i class="fas fa-user-plus"></i> إضافة طالب جديد
+                    </a>
+                @endcan
+            </div>
+
+            <form method="GET" action="{{ route('students.index') }}" class="row g-3">
+                <div class="col-md-6 col-lg-4">
+                    <label class="form-label">بحث</label>
+                    <input type="text" name="search" value="{{ $filters['search'] }}" class="form-control" placeholder="ابحث باسم الطالب أو البريد أو اسم الدخول">
+                </div>
+                <div class="col-md-6 col-lg-4">
+                    <label class="form-label">الحالة</label>
+                    <select name="status" class="form-select">
+                        <option value="">الحالة (الكل)</option>
+                        <option value="active" @selected(request('status') === 'active')>نشط</option>
+                        <option value="inactive" @selected(request('status') === 'inactive')>غير نشط</option>
+                    </select>
+                </div>
+                <div class="col-12 col-lg-4 d-flex align-items-end gap-2">
+                    <a href="{{ route('students.index') }}" class="btn btn-outline-secondary w-100">
+                        <i class="fas fa-rotate-left"></i> إعادة تعيين
+                    </a>
+                    <button type="submit" class="btn btn-primary w-100">
+                        <i class="fas fa-search"></i> عرض النتائج
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>الطالب</th>
+                            <th>البريد الإلكتروني</th>
+                            <th>رقم الهاتف</th>
+                            <th class="text-center">الحالة</th>
+                            <th>آخر تسجيل دخول</th>
+                            <th>تاريخ التسجيل</th>
+                            <th class="text-center">الإجراءات</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($students as $student)
+                            <tr>
+                                <td>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <img src="{{ $student->avatar_url }}" class="rounded-circle" width="42" height="42" alt="{{ $student->name }}">
+                                        <div>
+                                            <div class="fw-semibold">{{ $student->name }}</div>
+                                            <small class="text-muted" dir="ltr">{{ $student->username }}</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td dir="ltr">{{ $student->email ?? '—' }}</td>
+                                <td dir="ltr">{{ $student->phone ?? '—' }}</td>
+                                <td class="text-center">
+                                    <span class="badge {{ $student->active ? 'bg-success' : 'bg-danger' }}">
+                                        {{ $student->active ? 'نشط' : 'غير نشط' }}
+                                    </span>
+                                </td>
+                                <td>{{ $student->last_login_at ? $student->last_login_at->diffForHumans() : 'لم يسجل بعد' }}</td>
+                                <td>{{ optional($student->created_at)->format('Y-m-d') }}</td>
+                                <td class="text-center">
+                                    <div class="btn-group" role="group">
+                                        @can('view_students')
+                                            <a href="{{ route('students.show', $student) }}" class="btn btn-sm btn-outline-primary" title="عرض التفاصيل">
+                                                <i class="fas fa-eye"></i>
+                                            </a>
+                                        @endcan
+                                        @can('edit_students')
+                                            <a href="{{ route('students.edit', $student) }}" class="btn btn-sm btn-outline-secondary" title="تعديل">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                            <form action="{{ route('students.toggle-status', $student) }}" method="POST" class="d-inline">
+                                                @csrf
+                                                @method('PATCH')
+                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="تغيير الحالة" onclick="return confirm('هل أنت متأكد من تغيير حالة الطالب؟');">
+                                                    <i class="fas fa-user-shield"></i>
+                                                </button>
+                                            </form>
+                                            <form action="{{ route('students.reset-password', $student) }}" method="POST" class="d-inline">
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-info" title="إعادة تعيين كلمة المرور" onclick="return confirm('سيتم إنشاء كلمة مرور جديدة للطالب، هل تريد المتابعة؟');">
+                                                    <i class="fas fa-key"></i>
+                                                </button>
+                                            </form>
+                                        @endcan
+                                        @can('delete_students')
+                                            <form action="{{ route('students.destroy', $student) }}" method="POST" class="d-inline">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="حذف" onclick="return confirm('هل أنت متأكد من حذف هذا الطالب؟ لا يمكن التراجع عن هذا الإجراء.');">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        @endcan
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center py-5 text-muted">
+                                    <i class="fas fa-user-graduate fa-2x mb-3"></i>
+                                    <p class="mb-0">لا توجد بيانات طلاب لعرضها حالياً.</p>
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @if($students instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)
+            <div class="card-footer d-flex justify-content-between align-items-center">
+                <div class="text-muted">عرض {{ $students->count() }} من {{ $students->total() }} طالب</div>
+                {{ $students->links() }}
+            </div>
+        @endif
+    </div>
+@endsection
+

--- a/modules/Students/Resources/views/partials/form.blade.php
+++ b/modules/Students/Resources/views/partials/form.blade.php
@@ -1,0 +1,54 @@
+@php($formStudent = $student ?? null)
+
+<div class="row g-4">
+    <div class="col-md-6">
+        <label class="form-label">اسم الطالب الكامل <span class="text-danger">*</span></label>
+        <input type="text" name="name" value="{{ old('name', $formStudent?->name) }}" class="form-control" required>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">اسم الدخول <span class="text-danger">*</span></label>
+        <input type="text" name="username" value="{{ old('username', $formStudent?->username) }}" class="form-control" dir="ltr" required>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">البريد الإلكتروني <span class="text-danger">*</span></label>
+        <input type="email" name="email" value="{{ old('email', $formStudent?->email) }}" class="form-control" dir="ltr" required>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">رقم الهاتف</label>
+        <input type="text" name="phone" value="{{ old('phone', $formStudent?->phone) }}" class="form-control" dir="ltr">
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">كلمة المرور{{ isset($formStudent) && $formStudent?->exists ? ' (اختياري)' : '' }} <span class="text-danger">{{ isset($formStudent) && $formStudent?->exists ? '' : '*' }}</span></label>
+        <input type="password" name="password" class="form-control" {{ isset($formStudent) && $formStudent?->exists ? '' : 'required' }}>
+        <small class="text-muted">{{ isset($formStudent) && $formStudent?->exists ? 'اترك الحقل فارغاً في حال عدم الرغبة بتغيير كلمة المرور.' : 'الحد الأدنى 8 أحرف.' }}</small>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">تأكيد كلمة المرور {{ isset($formStudent) && $formStudent?->exists ? '(اختياري)' : '' }}</label>
+        <input type="password" name="password_confirmation" class="form-control" {{ isset($formStudent) && $formStudent?->exists ? '' : 'required' }}>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">صورة الطالب</label>
+        <input type="file" name="avatar" class="form-control" accept="image/*">
+        <small class="text-muted">الحد الأقصى للحجم 2 ميجابايت.</small>
+        @if($formStudent?->avatar)
+            <div class="mt-2 d-flex align-items-center gap-3">
+                <img src="{{ $formStudent->avatar_url }}" alt="صورة الطالب" class="rounded-circle" width="48" height="48">
+                <span class="text-muted">الصورة الحالية</span>
+            </div>
+        @endif
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">حالة الحساب</label>
+        <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" role="switch" id="student-active" name="active" value="1" @checked(old('active', $formStudent?->active ?? true))>
+            <label class="form-check-label" for="student-active">{{ old('active', $formStudent?->active ?? true) ? 'نشط' : 'غير نشط' }}</label>
+        </div>
+    </div>
+</div>

--- a/modules/Students/Resources/views/reports.blade.php
+++ b/modules/Students/Resources/views/reports.blade.php
@@ -1,0 +1,110 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تقارير الطلاب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تقارير الطلاب')
+    @section('page-subtitle', 'نظرة عامة على التسجيلات والنشاط الحديث')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">التقارير</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-md-4">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon students"><i class="fas fa-user-graduate"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ $statistics['total'] }}</div>
+                    <div class="stat-label">إجمالي الطلاب</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-check"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-success">{{ $statistics['active'] }}</div>
+                    <div class="stat-label">طلاب نشطون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon teachers"><i class="fas fa-user-slash"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-danger">{{ $statistics['inactive'] }}</div>
+                    <div class="stat-label">طلاب غير نشطين</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0"><i class="fas fa-history me-2"></i> آخر الطلاب المسجلين</h5>
+            <span class="text-muted">آخر {{ $recentStudents->count() }} طلاب</span>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>الطالب</th>
+                            <th>البريد الإلكتروني</th>
+                            <th>الحالة</th>
+                            <th>تاريخ التسجيل</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($recentStudents as $student)
+                            <tr>
+                                <td>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <img src="{{ $student->avatar_url }}" class="rounded-circle" width="36" height="36" alt="{{ $student->name }}">
+                                        <div>
+                                            <div class="fw-semibold">{{ $student->name }}</div>
+                                            <small class="text-muted" dir="ltr">{{ $student->username }}</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td dir="ltr">{{ $student->email ?? '—' }}</td>
+                                <td>
+                                    <span class="badge {{ $student->active ? 'bg-success' : 'bg-danger' }}">{{ $student->active ? 'نشط' : 'غير نشط' }}</span>
+                                </td>
+                                <td>{{ $student->created_at?->diffForHumans() ?? 'غير متوفر' }}</td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4" class="text-center py-4 text-muted">لا توجد بيانات حديثة لعرضها.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fas fa-lightbulb me-2"></i> ملاحظات إرشادية</h5>
+        </div>
+        <div class="card-body">
+            <ul class="list-unstyled mb-0">
+                <li class="mb-2"><i class="fas fa-check-circle text-success me-2"></i> قم بمتابعة الطلاب غير النشطين لتحديث بياناتهم أو إغلاق حساباتهم إن لزم.</li>
+                <li class="mb-2"><i class="fas fa-check-circle text-success me-2"></i> يمكن تصدير تقارير تفصيلية لاحقاً عند إضافة تكامل مع Excel.</li>
+                <li class="mb-0"><i class="fas fa-check-circle text-success me-2"></i> استخدم هذه الصفحة لمراقبة التسجيلات الحديثة واتخاذ الإجراءات المناسبة.</li>
+            </ul>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/show.blade.php
+++ b/modules/Students/Resources/views/show.blade.php
@@ -1,0 +1,151 @@
+@extends('admin.layouts.master')
+
+@section('title', 'ملف الطالب - ' . $student->name)
+
+@section('page-header')
+    @section('page-title', 'ملف الطالب')
+    @section('page-subtitle', 'عرض بيانات الطالب ومتابعة نشاطه')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">{{ $student->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-body text-center">
+                    <img src="{{ $student->avatar_url }}" class="rounded-circle mb-3" width="120" height="120" alt="{{ $student->name }}">
+                    <h4 class="fw-semibold">{{ $student->name }}</h4>
+                    <span class="badge bg-primary-subtle text-primary mb-3">
+                        {{ $student->roles->first()->display_name ?? $student->roles->first()->name ?? 'طالب' }}
+                    </span>
+
+                    <div class="d-flex flex-column gap-2 text-start">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fas fa-envelope text-primary"></i>
+                            <span dir="ltr">{{ $student->email ?? '—' }}</span>
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fas fa-user text-primary"></i>
+                            <span dir="ltr">{{ $student->username }}</span>
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fas fa-phone text-primary"></i>
+                            <span dir="ltr">{{ $student->phone ?? '—' }}</span>
+                        </div>
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fas fa-toggle-on text-primary"></i>
+                            <span>{{ $student->active ? 'حساب نشط' : 'حساب غير نشط' }}</span>
+                        </div>
+                    </div>
+
+                    <hr class="my-4">
+
+                    <div class="text-start">
+                        <p class="text-muted mb-1">آخر تسجيل دخول:</p>
+                        <p class="fw-semibold">{{ $student->last_login_at ? $student->last_login_at->format('Y-m-d H:i') : 'لم يسجل بعد' }}</p>
+                        <p class="text-muted mb-1">عنوان IP الأخير:</p>
+                        <p class="fw-semibold" dir="ltr">{{ $student->last_login_ip ?? '—' }}</p>
+                        <p class="text-muted mb-1">تاريخ الإنشاء:</p>
+                        <p class="fw-semibold">{{ $student->created_at?->format('Y-m-d') ?? 'غير متوفر' }}</p>
+                        <p class="text-muted mb-1">آخر تحديث:</p>
+                        <p class="fw-semibold">{{ $student->updated_at?->diffForHumans() ?? 'غير متوفر' }}</p>
+                    </div>
+
+                    <div class="d-flex flex-column gap-2 mt-4">
+                        @can('edit_students')
+                            <a href="{{ route('students.edit', $student) }}" class="btn btn-primary">
+                                <i class="fas fa-edit"></i> تعديل البيانات
+                            </a>
+                            <form action="{{ route('students.toggle-status', $student) }}" method="POST" onsubmit="return confirm('هل أنت متأكد من تغيير حالة الطالب؟');">
+                                @csrf
+                                @method('PATCH')
+                                <button type="submit" class="btn btn-outline-warning">
+                                    <i class="fas fa-user-shield"></i> {{ $student->active ? 'إيقاف التفعيل' : 'تفعيل الحساب' }}
+                                </button>
+                            </form>
+                            <form action="{{ route('students.reset-password', $student) }}" method="POST" onsubmit="return confirm('سيتم إنشاء كلمة مرور جديدة للطالب، هل تريد المتابعة؟');">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-info">
+                                    <i class="fas fa-key"></i> إعادة تعيين كلمة المرور
+                                </button>
+                            </form>
+                        @endcan
+                        @can('delete_students')
+                            <form action="{{ route('students.destroy', $student) }}" method="POST" onsubmit="return confirm('هل أنت متأكد من حذف هذا الطالب؟ لا يمكن التراجع عن هذا الإجراء.');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-danger">
+                                    <i class="fas fa-trash"></i> حذف الطالب
+                                </button>
+                            </form>
+                        @endcan
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-8">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-user-lock me-2"></i> الصلاحيات المرتبطة بالحساب</h5>
+                    <span class="badge bg-secondary-subtle text-secondary">{{ $rolePermissions->count() }} صلاحية</span>
+                </div>
+                <div class="card-body">
+                    @if($rolePermissions->isEmpty())
+                        <div class="text-center text-muted py-4">
+                            <i class="fas fa-lock-open fa-2x mb-3"></i>
+                            <p class="mb-0">لا توجد صلاحيات إضافية مرتبطة بهذا الطالب.</p>
+                        </div>
+                    @else
+                        <div class="row g-3">
+                            @foreach($rolePermissions->chunk(ceil($rolePermissions->count() / 2)) as $column)
+                                <div class="col-md-6">
+                                    <ul class="list-group list-group-flush">
+                                        @foreach($column as $permission)
+                                            <li class="list-group-item">
+                                                <i class="fas fa-check-circle text-success me-2"></i>{{ $permission }}
+                                            </li>
+                                        @endforeach
+                                    </ul>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-chart-line me-2"></i> إحصائيات الحساب</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-4">
+                        <div class="col-md-6">
+                            <div class="border rounded p-3 h-100">
+                                <h6 class="text-muted">عدد الأنشطة المسجلة</h6>
+                                <p class="fw-bold mb-0">{{ $activityCount }}</p>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="border rounded p-3 h-100">
+                                <h6 class="text-muted">آخر تحديث للدور</h6>
+                                <p class="fw-bold mb-0">{{ optional($student->roles->first()?->pivot)->created_at?->diffForHumans() ?? 'غير متوفر' }}</p>
+                            </div>
+                        </div>
+                        <div class="col-12">
+                            <div class="border rounded p-3">
+                                <h6 class="text-muted">ملاحظات إدارية</h6>
+                                <p class="mb-0 text-muted">يمكنك إضافة نظام لملاحظات الأداء والسلوك في التحديثات القادمة.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Routes/web.php
+++ b/modules/Students/Routes/web.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+use Modules\Students\Http\Controllers\StudentController;
+
+Route::middleware(['web', 'auth'])->group(function () {
+    Route::bind('student', function ($value) {
+        return User::whereKey($value)
+            ->whereHas('roles', fn ($query) => $query->where('name', 'student'))
+            ->firstOrFail();
+    });
+
+    Route::prefix('students')
+        ->name('students.')
+        ->group(function () {
+            Route::get('/', [StudentController::class, 'index'])->name('index')->middleware('can:view_students');
+            Route::get('/create', [StudentController::class, 'create'])->name('create')->middleware('can:create_students');
+            Route::post('/', [StudentController::class, 'store'])->name('store')->middleware('can:create_students');
+            Route::get('/reports', [StudentController::class, 'reports'])->name('reports')->middleware('can:view_students');
+            Route::get('/{student}', [StudentController::class, 'show'])->name('show')->middleware('can:view_students')->whereNumber('student');
+            Route::get('/{student}/edit', [StudentController::class, 'edit'])->name('edit')->middleware('can:edit_students')->whereNumber('student');
+            Route::put('/{student}', [StudentController::class, 'update'])->name('update')->middleware('can:edit_students')->whereNumber('student');
+            Route::delete('/{student}', [StudentController::class, 'destroy'])->name('destroy')->middleware('can:delete_students')->whereNumber('student');
+            Route::patch('/{student}/toggle-status', [StudentController::class, 'toggleStatus'])->name('toggle-status')->middleware('can:edit_students')->whereNumber('student');
+            Route::post('/{student}/reset-password', [StudentController::class, 'resetPassword'])->name('reset-password')->middleware('can:edit_students')->whereNumber('student');
+        });
+});

--- a/modules/Students/module.json
+++ b/modules/Students/module.json
@@ -1,0 +1,10 @@
+{
+    "name": "Students",
+    "alias": "students",
+    "description": "إدارة حسابات الطلاب ومتابعة بياناتهم.",
+    "keywords": ["students", "enrollment", "profiles"],
+    "priority": 0,
+    "providers": [
+        "Modules\\Students\\Providers\\StudentServiceProvider"
+    ]
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,3 +1,4 @@
 {
-    "Users": true
+    "Users": true,
+    "Students": true
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,15 +18,6 @@ Route::middleware(['auth'])->group(function () {
     // Main Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
-    // Students Routes
-    Route::prefix('students')->name('students.')->group(function () {
-        Route::get('/', function() { return view('students.index'); })->name('index')->middleware('can:view_students');
-        Route::get('/create', function() { return view('students.create'); })->name('create')->middleware('can:create_students');
-        Route::get('/{student}', function() { return view('students.show'); })->name('show')->middleware('can:view_students');
-        Route::get('/{student}/edit', function() { return view('students.edit'); })->name('edit')->middleware('can:edit_students');
-        Route::get('/reports', function() { return view('students.reports'); })->name('reports')->middleware('can:view_students');
-    });
-
     // Teachers Routes
     Route::prefix('teachers')->name('teachers.')->group(function () {
         Route::get('/', function() { return view('teachers.index'); })->name('index')->middleware('can:view_teachers');


### PR DESCRIPTION
## Summary
- load module service providers declared in each module's configuration file
- filter student and parent roles out of the Users module listings and statistics
- add a dedicated Students module with routes, controllers, forms, and views for managing student accounts and reports

## Testing
- `php artisan test` *(fails: vendor/autoload.php is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a323b4a4832fbfcc266fcb86b132