### PR TITLE
Add core teaching and curriculum modules

### DIFF
--- a/app/Models/SchoolClass.php
+++ b/app/Models/SchoolClass.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class SchoolClass extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'grade_level',
+        'section',
+        'capacity',
+        'teacher_id',
+        'room_number',
+        'notes',
+    ];
+
+    protected $casts = [
+        'capacity' => 'integer',
+    ];
+
+    public function homeroomTeacher()
+    {
+        return $this->belongsTo(Teacher::class, 'teacher_id');
+    }
+
+    public function scopeFilter(Builder $query, array $filters): void
+    {
+        $query->when($filters['search'] ?? null, function (Builder $builder, string $search) {
+            $builder->where(function (Builder $query) use ($search) {
+                $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('grade_level', 'like', "%{$search}%")
+                    ->orWhere('section', 'like', "%{$search}%");
+            });
+        });
+
+        $query->when($filters['grade_level'] ?? null, function (Builder $builder, string $grade) {
+            $builder->where('grade_level', $grade);
+        });
+    }
+}

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+class Student extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    public const STATUSES = [
+        'active' => 'طالب منتظم',
+        'inactive' => 'موقوف مؤقتًا',
+        'graduated' => 'متخرج',
+        'transferred' => 'منقول',
+    ];
+
+    public const GENDERS = [
+        'male' => 'ذكر',
+        'female' => 'أنثى',
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'student_code',
+        'name',
+        'english_name',
+        'gender',
+        'birth_date',
+        'national_id',
+        'grade_level',
+        'classroom',
+        'enrollment_date',
+        'status',
+        'email',
+        'phone',
+        'guardian_name',
+        'guardian_relationship',
+        'guardian_phone',
+        'address',
+        'city',
+        'transportation_method',
+        'outstanding_fees',
+        'medical_notes',
+        'notes',
+        'created_by',
+        'updated_by',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'birth_date' => 'date',
+        'enrollment_date' => 'date',
+        'outstanding_fees' => 'decimal:2',
+    ];
+
+    /**
+     * Scope a query to apply the provided filters.
+     */
+    public function scopeFilter(Builder $query, array $filters): void
+    {
+        $query->when($filters['search'] ?? null, function (Builder $builder, string $search) {
+            $builder->where(function (Builder $query) use ($search) {
+                $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('english_name', 'like', "%{$search}%")
+                    ->orWhere('student_code', 'like', "%{$search}%")
+                    ->orWhere('national_id', 'like', "%{$search}%")
+                    ->orWhere('guardian_name', 'like', "%{$search}%");
+            });
+        });
+
+        $query->when($filters['grade_level'] ?? null, function (Builder $builder, string $grade) {
+            $builder->where('grade_level', $grade);
+        });
+
+        $query->when($filters['status'] ?? null, function (Builder $builder, string $status) {
+            $builder->where('status', $status);
+        });
+
+        $query->when($filters['gender'] ?? null, function (Builder $builder, string $gender) {
+            $builder->where('gender', $gender);
+        });
+
+        $query->when($filters['enrollment_year'] ?? null, function (Builder $builder, string $year) {
+            $builder->whereYear('enrollment_date', $year);
+        });
+    }
+
+    /**
+     * Create a unique student code when none is provided.
+     */
+    public static function generateStudentCode(): string
+    {
+        do {
+            $code = sprintf('STU-%s-%s', now()->format('Y'), Str::upper(Str::random(5)));
+        } while (static::where('student_code', $code)->exists());
+
+        return $code;
+    }
+
+    /**
+     * Retrieve the localized label for the current status.
+     */
+    public function getStatusLabelAttribute(): string
+    {
+        return self::STATUSES[$this->status] ?? 'غير محدد';
+    }
+
+    /**
+     * Retrieve the localized label for the gender attribute.
+     */
+    public function getGenderLabelAttribute(): ?string
+    {
+        return $this->gender ? (self::GENDERS[$this->gender] ?? $this->gender) : null;
+    }
+
+    /**
+     * Calculate the current age of the student.
+     */
+    public function getAgeAttribute(): ?int
+    {
+        return $this->birth_date instanceof Carbon ? $this->birth_date->age : null;
+    }
+
+    /**
+     * Extract the enrollment year from the enrollment date.
+     */
+    public function getEnrollmentYearAttribute(): ?string
+    {
+        return $this->enrollment_date instanceof Carbon ? $this->enrollment_date->format('Y') : null;
+    }
+
+    /**
+     * Retrieve the initials of the student to use in avatars.
+     */
+    public function getInitialsAttribute(): string
+    {
+        $segments = preg_split('/\s+/u', trim($this->name));
+
+        return Str::upper(Str::limit(collect($segments)->map(fn ($part) => Str::substr($part, 0, 1))->implode(''), 2, ''));
+    }
+
+    /**
+     * Available statuses for selection controls.
+     */
+    public static function statusOptions(): array
+    {
+        return self::STATUSES;
+    }
+
+    /**
+     * Available gender options for selection controls.
+     */
+    public static function genderOptions(): array
+    {
+        return self::GENDERS;
+    }
+
+    /**
+     * Helper to normalise fillable payload.
+     */
+    public static function preparePayload(array $attributes): array
+    {
+        $allowed = (new static())->getFillable();
+
+        return Arr::only($attributes, $allowed);
+    }
+}

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Subject extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'code',
+        'name',
+        'grade_level',
+        'teacher_id',
+        'description',
+        'weekly_hours',
+    ];
+
+    protected $casts = [
+        'weekly_hours' => 'integer',
+    ];
+
+    public function teacher()
+    {
+        return $this->belongsTo(Teacher::class);
+    }
+
+    public function scopeFilter(Builder $query, array $filters): void
+    {
+        $query->when($filters['search'] ?? null, function (Builder $builder, string $search) {
+            $builder->where(function (Builder $query) use ($search) {
+                $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('code', 'like', "%{$search}%")
+                    ->orWhere('grade_level', 'like', "%{$search}%");
+            });
+        });
+
+        $query->when($filters['grade_level'] ?? null, function (Builder $builder, string $grade) {
+            $builder->where('grade_level', $grade);
+        });
+    }
+}

--- a/app/Models/Teacher.php
+++ b/app/Models/Teacher.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+class Teacher extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    public const STATUSES = [
+        'active' => 'على رأس العمل',
+        'vacation' => 'إجازة',
+        'suspended' => 'موقوف',
+        'resigned' => 'مستقيل',
+    ];
+
+    protected $fillable = [
+        'employee_code',
+        'name',
+        'english_name',
+        'email',
+        'phone',
+        'specialization',
+        'hire_date',
+        'salary',
+        'status',
+        'notes',
+    ];
+
+    protected $casts = [
+        'hire_date' => 'date',
+        'salary' => 'decimal:2',
+    ];
+
+    public function scopeFilter(Builder $query, array $filters): void
+    {
+        $query->when($filters['search'] ?? null, function (Builder $builder, string $search) {
+            $builder->where(function (Builder $query) use ($search) {
+                $query->where('name', 'like', "%{$search}%")
+                    ->orWhere('english_name', 'like', "%{$search}%")
+                    ->orWhere('employee_code', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%")
+                    ->orWhere('phone', 'like', "%{$search}%");
+            });
+        });
+
+        $query->when($filters['status'] ?? null, function (Builder $builder, string $status) {
+            $builder->where('status', $status);
+        });
+    }
+
+    public static function generateEmployeeCode(): string
+    {
+        do {
+            $code = sprintf('EMP-%s', Str::upper(Str::random(6)));
+        } while (static::where('employee_code', $code)->exists());
+
+        return $code;
+    }
+
+    public function getStatusLabelAttribute(): string
+    {
+        return self::STATUSES[$this->status] ?? 'غير محدد';
+    }
+}

--- a/database/migrations/2025_09_02_000000_create_students_table.php
+++ b/database/migrations/2025_09_02_000000_create_students_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('students', function (Blueprint $table) {
+            $table->id();
+            $table->string('student_code')->unique();
+            $table->string('name');
+            $table->string('english_name')->nullable();
+            $table->enum('gender', ['male', 'female'])->nullable();
+            $table->date('birth_date')->nullable();
+            $table->string('national_id')->nullable();
+            $table->string('grade_level');
+            $table->string('classroom')->nullable();
+            $table->date('enrollment_date')->nullable();
+            $table->string('status')->default('active');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('guardian_name')->nullable();
+            $table->string('guardian_relationship')->nullable();
+            $table->string('guardian_phone')->nullable();
+            $table->string('address')->nullable();
+            $table->string('city')->nullable();
+            $table->string('transportation_method')->nullable();
+            $table->decimal('outstanding_fees', 10, 2)->default(0);
+            $table->text('medical_notes')->nullable();
+            $table->text('notes')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['grade_level', 'classroom']);
+            $table->index('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('students');
+    }
+};

--- a/database/migrations/2025_09_02_010000_create_teachers_table.php
+++ b/database/migrations/2025_09_02_010000_create_teachers_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('teachers', function (Blueprint $table) {
+            $table->id();
+            $table->string('employee_code')->unique();
+            $table->string('name');
+            $table->string('english_name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('specialization')->nullable();
+            $table->date('hire_date')->nullable();
+            $table->decimal('salary', 10, 2)->default(0);
+            $table->string('status')->default('active');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teachers');
+    }
+};

--- a/database/migrations/2025_09_02_020000_create_school_classes_table.php
+++ b/database/migrations/2025_09_02_020000_create_school_classes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('school_classes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('grade_level');
+            $table->string('section')->nullable();
+            $table->unsignedInteger('capacity')->default(0);
+            $table->foreignId('teacher_id')->nullable()->constrained('teachers')->nullOnDelete();
+            $table->string('room_number')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('school_classes');
+    }
+};

--- a/database/migrations/2025_09_02_030000_create_subjects_table.php
+++ b/database/migrations/2025_09_02_030000_create_subjects_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('subjects', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('name');
+            $table->string('grade_level');
+            $table->foreignId('teacher_id')->nullable()->constrained('teachers')->nullOnDelete();
+            $table->unsignedInteger('weekly_hours')->default(0);
+            $table->text('description')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subjects');
+    }
+};

--- a/modules/Classes/Http/Controllers/ClassController.php
+++ b/modules/Classes/Http/Controllers/ClassController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Modules\Classes\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\SchoolClass;
+use App\Models\Teacher;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Modules\Classes\Http\Requests\StoreClassRequest;
+use Modules\Classes\Http\Requests\UpdateClassRequest;
+
+class ClassController extends Controller
+{
+    public function index(Request $request): View|ViewFactory
+    {
+        $classes = SchoolClass::query()
+            ->with('homeroomTeacher')
+            ->latest()
+            ->filter($request->only(['search', 'grade_level']))
+            ->paginate()
+            ->withQueryString();
+
+        return view('classes::index', [
+            'classes' => $classes,
+            'filters' => $request->only(['search', 'grade_level']),
+            'teachers' => Teacher::orderBy('name')->get(),
+        ]);
+    }
+
+    public function create(): View|ViewFactory
+    {
+        return view('classes::create', [
+            'class' => new SchoolClass(),
+            'teachers' => Teacher::orderBy('name')->get(),
+        ]);
+    }
+
+    public function store(StoreClassRequest $request): RedirectResponse
+    {
+        $class = SchoolClass::create($request->validated());
+
+        return redirect()->route('classes.show', $class)->with('success', 'تم إنشاء الفصل بنجاح.');
+    }
+
+    public function show(SchoolClass $class): View|ViewFactory
+    {
+        $class->load('homeroomTeacher');
+
+        return view('classes::show', [
+            'class' => $class,
+        ]);
+    }
+
+    public function edit(SchoolClass $class): View|ViewFactory
+    {
+        return view('classes::edit', [
+            'class' => $class,
+            'teachers' => Teacher::orderBy('name')->get(),
+        ]);
+    }
+
+    public function update(UpdateClassRequest $request, SchoolClass $class): RedirectResponse
+    {
+        $class->update($request->validated());
+
+        return redirect()->route('classes.show', $class)->with('success', 'تم تحديث بيانات الفصل.');
+    }
+
+    public function destroy(SchoolClass $class): RedirectResponse
+    {
+        $class->delete();
+
+        return redirect()->route('classes.index')->with('success', 'تم حذف الفصل.');
+    }
+}

--- a/modules/Classes/Http/Requests/StoreClassRequest.php
+++ b/modules/Classes/Http/Requests/StoreClassRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Modules\Classes\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreClassRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'grade_level' => ['required', 'string', 'max:100'],
+            'section' => ['nullable', 'string', 'max:50'],
+            'capacity' => ['nullable', 'integer', 'min:0'],
+            'teacher_id' => ['nullable', 'exists:teachers,id'],
+            'room_number' => ['nullable', 'string', 'max:50'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/modules/Classes/Http/Requests/UpdateClassRequest.php
+++ b/modules/Classes/Http/Requests/UpdateClassRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Modules\Classes\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateClassRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'grade_level' => ['required', 'string', 'max:100'],
+            'section' => ['nullable', 'string', 'max:50'],
+            'capacity' => ['nullable', 'integer', 'min:0'],
+            'teacher_id' => ['nullable', 'exists:teachers,id'],
+            'room_number' => ['nullable', 'string', 'max:50'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/modules/Classes/Providers/ClassesServiceProvider.php
+++ b/modules/Classes/Providers/ClassesServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Classes\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ClassesServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/../Routes/web.php');
+        $this->loadViewsFrom(__DIR__.'/../Resources/views', 'classes');
+        $this->publishes([
+            __DIR__.'/../Resources/views' => resource_path('views/vendor/classes'),
+        ], 'classes-views');
+    }
+}

--- a/modules/Classes/Resources/views/_form.blade.php
+++ b/modules/Classes/Resources/views/_form.blade.php
@@ -1,0 +1,61 @@
+@csrf
+<div class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">اسم الفصل</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', $class->name) }}" required>
+        @error('name')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">المرحلة</label>
+        <input type="text" name="grade_level" class="form-control" value="{{ old('grade_level', $class->grade_level) }}" required>
+        @error('grade_level')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">الشعبة</label>
+        <input type="text" name="section" class="form-control" value="{{ old('section', $class->section) }}">
+        @error('section')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">السعة</label>
+        <input type="number" name="capacity" class="form-control" value="{{ old('capacity', $class->capacity) }}">
+        @error('capacity')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">رائد الفصل</label>
+        <select name="teacher_id" class="form-select">
+            <option value="">—</option>
+            @foreach($teachers as $teacher)
+                <option value="{{ $teacher->id }}" @selected(old('teacher_id', $class->teacher_id) == $teacher->id)>{{ $teacher->name }}</option>
+            @endforeach
+        </select>
+        @error('teacher_id')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">رقم القاعة</label>
+        <input type="text" name="room_number" class="form-control" value="{{ old('room_number', $class->room_number) }}">
+        @error('room_number')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-12">
+        <label class="form-label">ملاحظات</label>
+        <textarea name="notes" rows="4" class="form-control">{{ old('notes', $class->notes) }}</textarea>
+        @error('notes')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+</div>
+<div class="mt-3 d-flex justify-content-between">
+    <a href="{{ route('classes.index') }}" class="btn btn-link">عودة</a>
+    <button class="btn btn-success">حفظ</button>
+</div>

--- a/modules/Classes/Resources/views/create.blade.php
+++ b/modules/Classes/Resources/views/create.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-3">إضافة فصل جديد</h1>
+    <div class="card">
+        <form method="post" action="{{ route('classes.store') }}" class="card-body">
+            @include('classes::_form')
+        </form>
+    </div>
+</div>
+@endsection

--- a/modules/Classes/Resources/views/edit.blade.php
+++ b/modules/Classes/Resources/views/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-3">تعديل الفصل</h1>
+    <div class="card">
+        <form method="post" action="{{ route('classes.update', $class) }}" class="card-body">
+            @method('put')
+            @include('classes::_form')
+        </form>
+    </div>
+</div>
+@endsection

--- a/modules/Classes/Resources/views/index.blade.php
+++ b/modules/Classes/Resources/views/index.blade.php
@@ -1,0 +1,69 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3">الفصول الدراسية</h1>
+        <a href="{{ route('classes.create') }}" class="btn btn-primary">إضافة فصل</a>
+    </div>
+
+    <form method="get" class="card card-body mb-3">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+                <label class="form-label">بحث</label>
+                <input type="text" name="search" value="{{ $filters['search'] ?? '' }}" class="form-control" placeholder="اسم الفصل أو المرحلة">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">المرحلة</label>
+                <input type="text" name="grade_level" value="{{ $filters['grade_level'] ?? '' }}" class="form-control">
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-outline-secondary w-100">تطبيق</button>
+            </div>
+        </div>
+    </form>
+
+    <div class="card">
+        <div class="card-body table-responsive">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>الاسم</th>
+                        <th>المرحلة</th>
+                        <th>الشعبة</th>
+                        <th>السعة</th>
+                        <th>رائد الفصل</th>
+                        <th class="text-end">إجراءات</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($classes as $class)
+                        <tr>
+                            <td><a href="{{ route('classes.show', $class) }}">{{ $class->name }}</a></td>
+                            <td>{{ $class->grade_level }}</td>
+                            <td>{{ $class->section ?? '—' }}</td>
+                            <td>{{ $class->capacity }}</td>
+                            <td>{{ $class->homeroomTeacher?->name ?? '—' }}</td>
+                            <td class="text-end">
+                                <a href="{{ route('classes.edit', $class) }}" class="btn btn-sm btn-outline-primary">تعديل</a>
+                                <form method="post" action="{{ route('classes.destroy', $class) }}" class="d-inline" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                                    @csrf
+                                    @method('delete')
+                                    <button class="btn btn-sm btn-outline-danger">حذف</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">لا توجد فصول مسجلة</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            {{ $classes->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/modules/Classes/Resources/views/show.blade.php
+++ b/modules/Classes/Resources/views/show.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h1 class="h3 mb-0">{{ $class->name }}</h1>
+            <div class="text-muted">{{ $class->grade_level }} @if($class->section) - {{ $class->section }} @endif</div>
+        </div>
+        <div class="btn-group">
+            <a href="{{ route('classes.edit', $class) }}" class="btn btn-outline-primary">تعديل</a>
+            <form method="post" action="{{ route('classes.destroy', $class) }}" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                @csrf
+                @method('delete')
+                <button class="btn btn-outline-danger">حذف</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">معلومات الفصل</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">السعة</dt>
+                        <dd class="col-sm-8">{{ $class->capacity ?? '—' }}</dd>
+                        <dt class="col-sm-4">رقم القاعة</dt>
+                        <dd class="col-sm-8">{{ $class->room_number ?? '—' }}</dd>
+                        <dt class="col-sm-4">رائد الفصل</dt>
+                        <dd class="col-sm-8">{{ $class->homeroomTeacher?->name ?? '—' }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">ملاحظات</div>
+                <div class="card-body">
+                    {{ $class->notes ?? 'لا توجد ملاحظات' }}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        <a href="{{ route('classes.index') }}" class="btn btn-link">عودة للقائمة</a>
+    </div>
+</div>
+@endsection

--- a/modules/Classes/Routes/web.php
+++ b/modules/Classes/Routes/web.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Classes\Http\Controllers\ClassController;
+
+Route::middleware(['web', 'auth'])
+    ->prefix('classes')
+    ->name('classes.')
+    ->group(function () {
+        Route::get('/', [ClassController::class, 'index'])
+            ->name('index')
+            ->middleware('can:view_classes');
+
+        Route::get('/create', [ClassController::class, 'create'])
+            ->name('create')
+            ->middleware('can:create_classes');
+
+        Route::post('/', [ClassController::class, 'store'])
+            ->name('store')
+            ->middleware('can:create_classes');
+
+        Route::get('/{class}', [ClassController::class, 'show'])
+            ->name('show')
+            ->middleware('can:view_classes');
+
+        Route::get('/{class}/edit', [ClassController::class, 'edit'])
+            ->name('edit')
+            ->middleware('can:edit_classes');
+
+        Route::put('/{class}', [ClassController::class, 'update'])
+            ->name('update')
+            ->middleware('can:edit_classes');
+
+        Route::delete('/{class}', [ClassController::class, 'destroy'])
+            ->name('destroy')
+            ->middleware('can:delete_classes');
+    });

--- a/modules/Classes/module.json
+++ b/modules/Classes/module.json
@@ -1,0 +1,8 @@
+{
+    "name": "Classes",
+    "alias": "classes",
+    "description": "إدارة الفصول الدراسية",
+    "providers": [
+        "Modules\\Classes\\Providers\\ClassesServiceProvider"
+    ]
+}

--- a/modules/Students/Http/Controllers/StudentController.php
+++ b/modules/Students/Http/Controllers/StudentController.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Modules\Students\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Student;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection as SupportCollection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\View\View;
+use Modules\Students\Http\Requests\StoreStudentRequest;
+use Modules\Students\Http\Requests\UpdateStudentRequest;
+
+class StudentController extends Controller
+{
+    /**
+     * Display a listing of the students.
+     */
+    public function index(Request $request): View
+    {
+        $filters = $this->filters($request);
+        $students = $this->filteredStudents($filters);
+
+        return view('students::index', [
+            'students' => $students,
+            'filters' => $filters,
+            'stats' => $this->studentStatistics(),
+            'grades' => $this->availableGrades(),
+            'enrollmentYears' => $this->availableEnrollmentYears(),
+            'statusOptions' => Student::statusOptions(),
+            'genderOptions' => Student::genderOptions(),
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new student.
+     */
+    public function create(): View
+    {
+        return view('students::create', $this->formOptions());
+    }
+
+    /**
+     * Store a newly created student in storage.
+     */
+    public function store(StoreStudentRequest $request): RedirectResponse
+    {
+        $payload = Student::preparePayload($request->validated());
+        $payload['student_code'] = $payload['student_code'] ?: Student::generateStudentCode();
+        $payload['created_by'] = $request->user()?->id;
+        $payload['updated_by'] = $request->user()?->id;
+
+        $student = Student::create($payload);
+
+        return Redirect::route('students.show', $student)
+            ->with('success', 'تم إضافة الطالب بنجاح إلى قاعدة البيانات.');
+    }
+
+    /**
+     * Display the specified student.
+     */
+    public function show(Student $student): View
+    {
+        return view('students::show', [
+            'student' => $student,
+            'statusOptions' => Student::statusOptions(),
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified student.
+     */
+    public function edit(Student $student): View
+    {
+        return view('students::edit', array_merge($this->formOptions(), [
+            'student' => $student,
+        ]));
+    }
+
+    /**
+     * Update the specified student in storage.
+     */
+    public function update(UpdateStudentRequest $request, Student $student): RedirectResponse
+    {
+        $payload = Student::preparePayload($request->validated());
+
+        if (empty($payload['student_code'])) {
+            unset($payload['student_code']);
+        }
+
+        $payload['updated_by'] = $request->user()?->id;
+
+        $student->update($payload);
+
+        return Redirect::route('students.show', $student)
+            ->with('success', 'تم تحديث بيانات الطالب بنجاح.');
+    }
+
+    /**
+     * Remove the specified student from storage.
+     */
+    public function destroy(Student $student): RedirectResponse
+    {
+        $student->delete();
+
+        return Redirect::route('students.index')
+            ->with('success', 'تم حذف سجل الطالب بنجاح.');
+    }
+
+    /**
+     * Display analytics and summary reports for students.
+     */
+    public function reports(Request $request): View
+    {
+        return view('students::reports', [
+            'statistics' => $this->studentStatistics(),
+            'gradeDistribution' => $this->gradeDistribution(),
+            'statusDistribution' => $this->statusDistribution(),
+            'genderDistribution' => $this->genderDistribution(),
+            'recentStudents' => $this->recentStudents(),
+            'topOutstandingBalances' => $this->topOutstandingBalances(),
+        ]);
+    }
+
+    /**
+     * Retrieve filtered students for the index page.
+     */
+    protected function filteredStudents(array $filters): LengthAwarePaginator
+    {
+        return Student::query()
+            ->filter($filters)
+            ->orderBy('name')
+            ->paginate(15)
+            ->withQueryString();
+    }
+
+    /**
+     * Extract filters from the incoming request.
+     */
+    protected function filters(Request $request): array
+    {
+        return [
+            'search' => trim((string) $request->input('search')) ?: null,
+            'grade_level' => $request->input('grade_level') ?: null,
+            'status' => $request->input('status') ?: null,
+            'gender' => $request->input('gender') ?: null,
+            'enrollment_year' => $request->input('enrollment_year') ?: null,
+        ];
+    }
+
+    /**
+     * Retrieve statistics used across the module.
+     */
+    protected function studentStatistics(): array
+    {
+        return [
+            'total' => Student::count(),
+            'active' => Student::where('status', 'active')->count(),
+            'inactive' => Student::where('status', 'inactive')->count(),
+            'male' => Student::where('gender', 'male')->count(),
+            'female' => Student::where('gender', 'female')->count(),
+        ];
+    }
+
+    /**
+     * Retrieve the distinct grade levels stored in the system.
+     */
+    protected function availableGrades(): SupportCollection
+    {
+        return Student::query()
+            ->select('grade_level')
+            ->whereNotNull('grade_level')
+            ->distinct()
+            ->orderBy('grade_level')
+            ->pluck('grade_level');
+    }
+
+    /**
+     * Retrieve the distinct enrollment years available.
+     */
+    protected function availableEnrollmentYears(): SupportCollection
+    {
+        return Student::query()
+            ->whereNotNull('enrollment_date')
+            ->selectRaw('DISTINCT YEAR(enrollment_date) AS enrollment_year')
+            ->orderBy('enrollment_year', 'desc')
+            ->pluck('enrollment_year');
+    }
+
+    /**
+     * Retrieve view data shared by create/edit forms.
+     */
+    protected function formOptions(): array
+    {
+        return [
+            'statusOptions' => Student::statusOptions(),
+            'genderOptions' => Student::genderOptions(),
+            'grades' => $this->availableGrades(),
+        ];
+    }
+
+    /**
+     * Retrieve distribution of students per grade.
+     */
+    protected function gradeDistribution(): SupportCollection
+    {
+        return Student::query()
+            ->select('grade_level', DB::raw('COUNT(*) as total'))
+            ->groupBy('grade_level')
+            ->orderBy('grade_level')
+            ->get()
+            ->map(function ($row) {
+                return [
+                    'grade_level' => $row->grade_level ?? 'غير محدد',
+                    'total' => (int) $row->total,
+                ];
+            });
+    }
+
+    /**
+     * Retrieve distribution of students by status.
+     */
+    protected function statusDistribution(): SupportCollection
+    {
+        return Student::query()
+            ->select('status', DB::raw('COUNT(*) as total'))
+            ->groupBy('status')
+            ->orderBy('status')
+            ->get()
+            ->map(function ($row) {
+                $label = Student::statusOptions()[$row->status] ?? $row->status;
+
+                return [
+                    'status' => $row->status,
+                    'label' => $label,
+                    'total' => (int) $row->total,
+                ];
+            });
+    }
+
+    /**
+     * Retrieve distribution of students by gender.
+     */
+    protected function genderDistribution(): SupportCollection
+    {
+        return Student::query()
+            ->select('gender', DB::raw('COUNT(*) as total'))
+            ->groupBy('gender')
+            ->orderBy('gender')
+            ->get()
+            ->map(function ($row) {
+                $label = Student::genderOptions()[$row->gender] ?? 'غير محدد';
+
+                return [
+                    'gender' => $row->gender,
+                    'label' => $label,
+                    'total' => (int) $row->total,
+                ];
+            });
+    }
+
+    /**
+     * Retrieve the most recently registered students.
+     */
+    protected function recentStudents(int $limit = 8): Collection
+    {
+        return Student::query()
+            ->latest()
+            ->take($limit)
+            ->get();
+    }
+
+    /**
+     * Retrieve students with the highest outstanding balances.
+     */
+    protected function topOutstandingBalances(int $limit = 5): Collection
+    {
+        return Student::query()
+            ->where('outstanding_fees', '>', 0)
+            ->orderByDesc('outstanding_fees')
+            ->take($limit)
+            ->get();
+    }
+}

--- a/modules/Students/Http/Requests/StoreStudentRequest.php
+++ b/modules/Students/Http/Requests/StoreStudentRequest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Modules\Students\Http\Requests;
+
+use App\Models\Student;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreStudentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create_students') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'student_code' => ['nullable', 'string', 'max:50', 'unique:students,student_code'],
+            'name' => ['required', 'string', 'max:255'],
+            'english_name' => ['nullable', 'string', 'max:255'],
+            'gender' => ['nullable', Rule::in(array_keys(Student::genderOptions()))],
+            'birth_date' => ['nullable', 'date', 'before:today'],
+            'national_id' => ['nullable', 'string', 'max:50'],
+            'grade_level' => ['required', 'string', 'max:120'],
+            'classroom' => ['nullable', 'string', 'max:120'],
+            'enrollment_date' => ['nullable', 'date'],
+            'status' => ['required', Rule::in(array_keys(Student::statusOptions()))],
+            'email' => ['nullable', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'guardian_name' => ['nullable', 'string', 'max:255'],
+            'guardian_relationship' => ['nullable', 'string', 'max:120'],
+            'guardian_phone' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'city' => ['nullable', 'string', 'max:120'],
+            'transportation_method' => ['nullable', 'string', 'max:120'],
+            'outstanding_fees' => ['nullable', 'numeric', 'min:0'],
+            'medical_notes' => ['nullable', 'string'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Sanitize the input before validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('outstanding_fees')) {
+            $this->merge([
+                'outstanding_fees' => $this->convertLocalizedNumber($this->input('outstanding_fees')),
+            ]);
+        }
+    }
+
+    /**
+     * Convert localized number inputs into float values.
+     */
+    protected function convertLocalizedNumber($value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        $normalized = str_replace([' ', '٬', ','], ['', '', '.'], $value);
+
+        return is_numeric($normalized) ? (float) $normalized : null;
+    }
+}

--- a/modules/Students/Http/Requests/UpdateStudentRequest.php
+++ b/modules/Students/Http/Requests/UpdateStudentRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Modules\Students\Http\Requests;
+
+use App\Models\Student;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateStudentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('edit_students') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        $studentId = $this->route('student')?->id ?? null;
+
+        return [
+            'student_code' => ['nullable', 'string', 'max:50', Rule::unique('students', 'student_code')->ignore($studentId)],
+            'name' => ['required', 'string', 'max:255'],
+            'english_name' => ['nullable', 'string', 'max:255'],
+            'gender' => ['nullable', Rule::in(array_keys(Student::genderOptions()))],
+            'birth_date' => ['nullable', 'date', 'before:today'],
+            'national_id' => ['nullable', 'string', 'max:50'],
+            'grade_level' => ['required', 'string', 'max:120'],
+            'classroom' => ['nullable', 'string', 'max:120'],
+            'enrollment_date' => ['nullable', 'date'],
+            'status' => ['required', Rule::in(array_keys(Student::statusOptions()))],
+            'email' => ['nullable', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'guardian_name' => ['nullable', 'string', 'max:255'],
+            'guardian_relationship' => ['nullable', 'string', 'max:120'],
+            'guardian_phone' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'city' => ['nullable', 'string', 'max:120'],
+            'transportation_method' => ['nullable', 'string', 'max:120'],
+            'outstanding_fees' => ['nullable', 'numeric', 'min:0'],
+            'medical_notes' => ['nullable', 'string'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('outstanding_fees')) {
+            $this->merge([
+                'outstanding_fees' => $this->convertLocalizedNumber($this->input('outstanding_fees')),
+            ]);
+        }
+    }
+
+    protected function convertLocalizedNumber($value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        $normalized = str_replace([' ', '٬', ','], ['', '', '.'], $value);
+
+        return is_numeric($normalized) ? (float) $normalized : null;
+    }
+}

--- a/modules/Students/Providers/StudentsServiceProvider.php
+++ b/modules/Students/Providers/StudentsServiceProvider.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\Students\Providers;
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+
+class StudentsServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $moduleBasePath = __DIR__ . '/../';
+
+        $this->loadRoutesFrom($moduleBasePath . 'Routes/web.php');
+        $this->loadViewsFrom($moduleBasePath . 'Resources/views', 'students');
+        $this->loadTranslationsFrom($moduleBasePath . 'Resources/lang', 'students');
+
+        $this->registerViewComponents();
+    }
+
+    /**
+     * Register reusable Blade components within the module.
+     */
+    protected function registerViewComponents(): void
+    {
+        $componentsPath = __DIR__ . '/../Resources/views/components';
+
+        if (! File::isDirectory($componentsPath)) {
+            return;
+        }
+
+        foreach (File::allFiles($componentsPath) as $component) {
+            $view = str_replace('.blade.php', '', $component->getRelativePathname());
+            $alias = 'students-' . str_replace(DIRECTORY_SEPARATOR, '-', $view);
+
+            Blade::component('students::components.' . str_replace(DIRECTORY_SEPARATOR, '.', $view), $alias);
+        }
+    }
+}

--- a/modules/Students/Resources/views/create.blade.php
+++ b/modules/Students/Resources/views/create.blade.php
@@ -1,0 +1,156 @@
+@extends('admin.layouts.master')
+
+@section('title', 'إضافة طالب جديد - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إضافة طالب جديد')
+    @section('page-subtitle', 'تسجيل طالب جديد في النظام وتحديد بياناته الأساسية')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">إضافة طالب</li>
+    @endsection
+@endsection
+
+@section('content')
+    <form action="{{ route('students.store') }}" method="POST" class="card shadow-sm">
+        @csrf
+        <div class="card-body">
+            <div class="row g-4">
+                <div class="col-md-6">
+                    <label class="form-label">اسم الطالب <span class="text-danger">*</span></label>
+                    <input type="text" name="name" value="{{ old('name') }}" class="form-control @error('name') is-invalid @enderror" placeholder="الاسم الكامل بالعربية" required>
+                    @error('name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">الاسم بالإنجليزية</label>
+                    <input type="text" name="english_name" value="{{ old('english_name') }}" class="form-control @error('english_name') is-invalid @enderror" placeholder="الاسم الكامل بالإنجليزية">
+                    @error('english_name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">كود الطالب</label>
+                    <input type="text" name="student_code" value="{{ old('student_code') }}" class="form-control @error('student_code') is-invalid @enderror" placeholder="سيتم توليده تلقائياً إذا تُرك فارغاً">
+                    @error('student_code')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الجنس</label>
+                    <select name="gender" class="form-select @error('gender') is-invalid @enderror">
+                        <option value="">حدد الجنس</option>
+                        @foreach($genderOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(old('gender') === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    @error('gender')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">تاريخ الميلاد</label>
+                    <input type="date" name="birth_date" value="{{ old('birth_date') }}" class="form-control @error('birth_date') is-invalid @enderror">
+                    @error('birth_date')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">الرقم القومي / هوية الطالب</label>
+                    <input type="text" name="national_id" value="{{ old('national_id') }}" class="form-control @error('national_id') is-invalid @enderror">
+                    @error('national_id')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الصف الدراسي <span class="text-danger">*</span></label>
+                    <input type="text" name="grade_level" value="{{ old('grade_level') }}" class="form-control @error('grade_level') is-invalid @enderror" placeholder="مثال: الصف الثالث الإعدادي" required>
+                    @error('grade_level')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الفصل</label>
+                    <input type="text" name="classroom" value="{{ old('classroom') }}" class="form-control @error('classroom') is-invalid @enderror" placeholder="مثال: 3/أ">
+                    @error('classroom')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">تاريخ القبول</label>
+                    <input type="date" name="enrollment_date" value="{{ old('enrollment_date') }}" class="form-control @error('enrollment_date') is-invalid @enderror">
+                    @error('enrollment_date')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الحالة <span class="text-danger">*</span></label>
+                    <select name="status" class="form-select @error('status') is-invalid @enderror" required>
+                        @foreach($statusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(old('status', 'active') === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    @error('status')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">البريد الإلكتروني</label>
+                    <input type="email" name="email" value="{{ old('email') }}" class="form-control @error('email') is-invalid @enderror" placeholder="example@student.com">
+                    @error('email')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">رقم الجوال</label>
+                    <input type="text" name="phone" value="{{ old('phone') }}" class="form-control @error('phone') is-invalid @enderror" placeholder="05xxxxxxxx">
+                    @error('phone')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">اسم ولي الأمر</label>
+                    <input type="text" name="guardian_name" value="{{ old('guardian_name') }}" class="form-control @error('guardian_name') is-invalid @enderror">
+                    @error('guardian_name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">صلة القرابة</label>
+                    <input type="text" name="guardian_relationship" value="{{ old('guardian_relationship') }}" class="form-control @error('guardian_relationship') is-invalid @enderror" placeholder="أب / أم / ولي أمر">
+                    @error('guardian_relationship')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">هاتف ولي الأمر</label>
+                    <input type="text" name="guardian_phone" value="{{ old('guardian_phone') }}" class="form-control @error('guardian_phone') is-invalid @enderror">
+                    @error('guardian_phone')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">العنوان</label>
+                    <input type="text" name="address" value="{{ old('address') }}" class="form-control @error('address') is-invalid @enderror">
+                    @error('address')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">المدينة / المركز</label>
+                    <input type="text" name="city" value="{{ old('city') }}" class="form-control @error('city') is-invalid @enderror">
+                    @error('city')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">وسيلة المواصلات</label>
+                    <input type="text" name="transportation_method" value="{{ old('transportation_method') }}" class="form-control @error('transportation_method') is-invalid @enderror" placeholder="حافلة المدرسة / ولي الأمر">
+                    @error('transportation_method')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">المستحقات المالية</label>
+                    <div class="input-group">
+                        <input type="number" step="0.01" min="0" name="outstanding_fees" value="{{ old('outstanding_fees', 0) }}" class="form-control @error('outstanding_fees') is-invalid @enderror">
+                        <span class="input-group-text">ج.م</span>
+                        @error('outstanding_fees')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                    </div>
+                </div>
+
+                <div class="col-md-6">
+                    <label class="form-label">ملاحظات طبية</label>
+                    <textarea name="medical_notes" rows="3" class="form-control @error('medical_notes') is-invalid @enderror" placeholder="أمراض مزمنة، حساسية، تعليمات خاصة">{{ old('medical_notes') }}</textarea>
+                    @error('medical_notes')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">ملاحظات إضافية</label>
+                    <textarea name="notes" rows="3" class="form-control @error('notes') is-invalid @enderror" placeholder="ملاحظات إدارية أو أكاديمية">{{ old('notes') }}</textarea>
+                    @error('notes')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-between align-items-center">
+            <a href="{{ route('students.index') }}" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-right"></i> العودة إلى قائمة الطلاب
+            </a>
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-save"></i> حفظ الطالب
+            </button>
+        </div>
+    </form>
+@endsection

--- a/modules/Students/Resources/views/edit.blade.php
+++ b/modules/Students/Resources/views/edit.blade.php
@@ -1,0 +1,158 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تعديل بيانات الطالب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تعديل بيانات الطالب')
+    @section('page-subtitle', 'تحديث بيانات الطالب والسجلات المرتبطة به')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.show', $student) }}">{{ $student->name }}</a></li>
+        <li class="breadcrumb-item active">تعديل</li>
+    @endsection
+@endsection
+
+@section('content')
+    <form action="{{ route('students.update', $student) }}" method="POST" class="card shadow-sm">
+        @csrf
+        @method('PUT')
+        <div class="card-body">
+            <div class="row g-4">
+                <div class="col-md-6">
+                    <label class="form-label">اسم الطالب <span class="text-danger">*</span></label>
+                    <input type="text" name="name" value="{{ old('name', $student->name) }}" class="form-control @error('name') is-invalid @enderror" required>
+                    @error('name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">الاسم بالإنجليزية</label>
+                    <input type="text" name="english_name" value="{{ old('english_name', $student->english_name) }}" class="form-control @error('english_name') is-invalid @enderror">
+                    @error('english_name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">كود الطالب</label>
+                    <input type="text" name="student_code" value="{{ old('student_code', $student->student_code) }}" class="form-control @error('student_code') is-invalid @enderror">
+                    @error('student_code')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الجنس</label>
+                    <select name="gender" class="form-select @error('gender') is-invalid @enderror">
+                        <option value="">حدد الجنس</option>
+                        @foreach($genderOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(old('gender', $student->gender) === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    @error('gender')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">تاريخ الميلاد</label>
+                    <input type="date" name="birth_date" value="{{ old('birth_date', optional($student->birth_date)->format('Y-m-d')) }}" class="form-control @error('birth_date') is-invalid @enderror">
+                    @error('birth_date')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">الرقم القومي / هوية الطالب</label>
+                    <input type="text" name="national_id" value="{{ old('national_id', $student->national_id) }}" class="form-control @error('national_id') is-invalid @enderror">
+                    @error('national_id')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الصف الدراسي <span class="text-danger">*</span></label>
+                    <input type="text" name="grade_level" value="{{ old('grade_level', $student->grade_level) }}" class="form-control @error('grade_level') is-invalid @enderror" required>
+                    @error('grade_level')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الفصل</label>
+                    <input type="text" name="classroom" value="{{ old('classroom', $student->classroom) }}" class="form-control @error('classroom') is-invalid @enderror">
+                    @error('classroom')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">تاريخ القبول</label>
+                    <input type="date" name="enrollment_date" value="{{ old('enrollment_date', optional($student->enrollment_date)->format('Y-m-d')) }}" class="form-control @error('enrollment_date') is-invalid @enderror">
+                    @error('enrollment_date')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">الحالة <span class="text-danger">*</span></label>
+                    <select name="status" class="form-select @error('status') is-invalid @enderror" required>
+                        @foreach($statusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(old('status', $student->status) === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    @error('status')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">البريد الإلكتروني</label>
+                    <input type="email" name="email" value="{{ old('email', $student->email) }}" class="form-control @error('email') is-invalid @enderror">
+                    @error('email')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">رقم الجوال</label>
+                    <input type="text" name="phone" value="{{ old('phone', $student->phone) }}" class="form-control @error('phone') is-invalid @enderror">
+                    @error('phone')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">اسم ولي الأمر</label>
+                    <input type="text" name="guardian_name" value="{{ old('guardian_name', $student->guardian_name) }}" class="form-control @error('guardian_name') is-invalid @enderror">
+                    @error('guardian_name')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">صلة القرابة</label>
+                    <input type="text" name="guardian_relationship" value="{{ old('guardian_relationship', $student->guardian_relationship) }}" class="form-control @error('guardian_relationship') is-invalid @enderror">
+                    @error('guardian_relationship')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">هاتف ولي الأمر</label>
+                    <input type="text" name="guardian_phone" value="{{ old('guardian_phone', $student->guardian_phone) }}" class="form-control @error('guardian_phone') is-invalid @enderror">
+                    @error('guardian_phone')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">العنوان</label>
+                    <input type="text" name="address" value="{{ old('address', $student->address) }}" class="form-control @error('address') is-invalid @enderror">
+                    @error('address')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">المدينة / المركز</label>
+                    <input type="text" name="city" value="{{ old('city', $student->city) }}" class="form-control @error('city') is-invalid @enderror">
+                    @error('city')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label class="form-label">وسيلة المواصلات</label>
+                    <input type="text" name="transportation_method" value="{{ old('transportation_method', $student->transportation_method) }}" class="form-control @error('transportation_method') is-invalid @enderror">
+                    @error('transportation_method')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">المستحقات المالية</label>
+                    <div class="input-group">
+                        <input type="number" step="0.01" min="0" name="outstanding_fees" value="{{ old('outstanding_fees', $student->outstanding_fees) }}" class="form-control @error('outstanding_fees') is-invalid @enderror">
+                        <span class="input-group-text">ج.م</span>
+                        @error('outstanding_fees')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                    </div>
+                </div>
+
+                <div class="col-md-6">
+                    <label class="form-label">ملاحظات طبية</label>
+                    <textarea name="medical_notes" rows="3" class="form-control @error('medical_notes') is-invalid @enderror">{{ old('medical_notes', $student->medical_notes) }}</textarea>
+                    @error('medical_notes')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">ملاحظات إضافية</label>
+                    <textarea name="notes" rows="3" class="form-control @error('notes') is-invalid @enderror">{{ old('notes', $student->notes) }}</textarea>
+                    @error('notes')<div class="invalid-feedback">{{ $message }}</div>@enderror
+                </div>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-between align-items-center">
+            <a href="{{ route('students.show', $student) }}" class="btn btn-outline-secondary">
+                <i class="fas fa-arrow-right"></i> إلغاء والعودة
+            </a>
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-save"></i> تحديث البيانات
+            </button>
+        </div>
+    </form>
+@endsection

--- a/modules/Students/Resources/views/index.blade.php
+++ b/modules/Students/Resources/views/index.blade.php
@@ -1,0 +1,217 @@
+@extends('admin.layouts.master')
+
+@section('title', 'إدارة الطلاب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إدارة الطلاب')
+    @section('page-subtitle', 'متابعة سجلات الطلاب وتحديث بياناتهم')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item active">الطلاب</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon students"><i class="fas fa-user-graduate"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ number_format($stats['total']) }}</div>
+                    <div class="stat-label">إجمالي الطلاب</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon teachers"><i class="fas fa-user-check"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-success">{{ number_format($stats['active']) }}</div>
+                    <div class="stat-label">طلاب منتظمون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-clock"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-warning">{{ number_format($stats['inactive']) }}</div>
+                    <div class="stat-label">طلاب بحاجة للمتابعة</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon achievements"><i class="fas fa-venus-mars"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ number_format($stats['male']) }} / {{ number_format($stats['female']) }}</div>
+                    <div class="stat-label">ذكور / إناث</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
+                <h5 class="mb-0"><i class="fas fa-filter me-2"></i> تصفية النتائج</h5>
+                <div class="d-flex gap-2">
+                    @can('view_students')
+                        <a href="{{ route('students.reports') }}" class="btn btn-outline-secondary">
+                            <i class="fas fa-chart-pie"></i> تقارير الطلاب
+                        </a>
+                    @endcan
+                    @can('create_students')
+                        <a href="{{ route('students.create') }}" class="btn btn-primary">
+                            <i class="fas fa-user-plus"></i> إضافة طالب جديد
+                        </a>
+                    @endcan
+                </div>
+            </div>
+
+            <form method="GET" action="{{ route('students.index') }}" class="row g-3">
+                <div class="col-md-3">
+                    <label class="form-label">بحث</label>
+                    <input type="text" name="search" value="{{ $filters['search'] }}" class="form-control" placeholder="ابحث بالاسم أو الكود أو ولي الأمر">
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">الصف الدراسي</label>
+                    <select name="grade_level" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($grades as $grade)
+                            <option value="{{ $grade }}" @selected($filters['grade_level'] === $grade)>{{ $grade }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">الحالة</label>
+                    <select name="status" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($statusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected($filters['status'] === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">النوع</label>
+                    <select name="gender" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($genderOptions as $value => $label)
+                            <option value="{{ $value }}" @selected($filters['gender'] === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">عام القبول</label>
+                    <select name="enrollment_year" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($enrollmentYears as $year)
+                            <option value="{{ $year }}" @selected($filters['enrollment_year'] == $year)>{{ $year }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-12 d-flex justify-content-end gap-2">
+                    <a href="{{ route('students.index') }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-rotate-left"></i> إعادة تعيين
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-search"></i> عرض النتائج
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>الكود</th>
+                            <th>الطالب</th>
+                            <th>الصف / الفصل</th>
+                            <th>ولي الأمر</th>
+                            <th class="text-center">الحالة</th>
+                            <th>الرصيد المستحق</th>
+                            <th>تاريخ القبول</th>
+                            <th class="text-center">الإجراءات</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($students as $student)
+                            <tr>
+                                <td dir="ltr">{{ $student->student_code }}</td>
+                                <td>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <div class="avatar-placeholder bg-primary text-white">
+                                            {{ $student->initials }}
+                                        </div>
+                                        <div>
+                                            <div class="fw-semibold">{{ $student->name }}</div>
+                                            <small class="text-muted d-block">{{ $student->gender_label ?? 'غير محدد' }}</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="fw-semibold">{{ $student->grade_level ?? '—' }}</div>
+                                    <small class="text-muted">{{ $student->classroom ?? '—' }}</small>
+                                </td>
+                                <td>
+                                    <div class="fw-semibold">{{ $student->guardian_name ?? '—' }}</div>
+                                    <small class="text-muted" dir="ltr">{{ $student->guardian_phone ?? '—' }}</small>
+                                </td>
+                                <td class="text-center">
+                                    <span class="badge bg-{{ $student->status === 'active' ? 'success' : ($student->status === 'inactive' ? 'warning' : 'info') }}">{{ $student->status_label }}</span>
+                                </td>
+                                <td>{{ number_format($student->outstanding_fees, 2) }} ج.م</td>
+                                <td>{{ $student->enrollment_date ? $student->enrollment_date->format('Y-m-d') : '—' }}</td>
+                                <td class="text-center">
+                                    <div class="btn-group" role="group">
+                                        @can('view_students')
+                                            <a href="{{ route('students.show', $student) }}" class="btn btn-sm btn-outline-primary" title="عرض التفاصيل">
+                                                <i class="fas fa-eye"></i>
+                                            </a>
+                                        @endcan
+                                        @can('edit_students')
+                                            <a href="{{ route('students.edit', $student) }}" class="btn btn-sm btn-outline-secondary" title="تعديل">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                        @endcan
+                                        @can('delete_students')
+                                            <form action="{{ route('students.destroy', $student) }}" method="POST" class="d-inline">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="حذف" onclick="return confirm('سيتم حذف سجل الطالب، هل أنت متأكد؟');">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        @endcan
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="8" class="text-center py-5">
+                                    <div class="text-muted">لا توجد سجلات طلاب مطابقة لمعايير البحث الحالية.</div>
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer">
+            {{ $students->links() }}
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/reports.blade.php
+++ b/modules/Students/Resources/views/reports.blade.php
@@ -1,0 +1,225 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تقارير الطلاب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تقارير الطلاب')
+    @section('page-subtitle', 'تحليل بيانات الطلاب وتوزيعهم على الصفوف والحالات المختلفة')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">التقارير</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon students"><i class="fas fa-users"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ number_format($statistics['total']) }}</div>
+                    <div class="stat-label">إجمالي الطلاب المسجلين</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon teachers"><i class="fas fa-user-check"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-success">{{ number_format($statistics['active']) }}</div>
+                    <div class="stat-label">طلاب نشطون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-clock"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-warning">{{ number_format($statistics['inactive']) }}</div>
+                    <div class="stat-label">طلاب تحت المراجعة</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3 col-sm-6">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon achievements"><i class="fas fa-venus-mars"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ number_format($statistics['male']) }} / {{ number_format($statistics['female']) }}</div>
+                    <div class="stat-label">ذكور / إناث</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-school me-2"></i> توزيع الطلاب حسب الصفوف</h5>
+                    <span class="badge bg-primary">{{ $gradeDistribution->sum('total') }} طالب</span>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>الصف الدراسي</th>
+                                    <th class="text-center">عدد الطلاب</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($gradeDistribution as $grade)
+                                    <tr>
+                                        <td>{{ $grade['grade_level'] }}</td>
+                                        <td class="text-center">
+                                            <span class="badge bg-secondary">{{ number_format($grade['total']) }}</span>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-clipboard-check me-2"></i> توزيع الطلاب حسب الحالة</h5>
+                    <span class="badge bg-primary">{{ $statusDistribution->sum('total') }} طالب</span>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>الحالة</th>
+                                    <th class="text-center">عدد الطلاب</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($statusDistribution as $status)
+                                    <tr>
+                                        <td>{{ $status['label'] }}</td>
+                                        <td class="text-center"><span class="badge bg-info">{{ number_format($status['total']) }}</span></td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-venus-mars me-2"></i> توزيع الطلاب حسب النوع</h5>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>النوع</th>
+                                    <th class="text-center">عدد الطلاب</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($genderDistribution as $gender)
+                                    <tr>
+                                        <td>{{ $gender['label'] }}</td>
+                                        <td class="text-center"><span class="badge bg-warning text-dark">{{ number_format($gender['total']) }}</span></td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-file-invoice-dollar me-2"></i> أعلى أرصدة مستحقة</h5>
+                    <span class="badge bg-danger">قيد المتابعة</span>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>الطالب</th>
+                                    <th>الصف</th>
+                                    <th class="text-end">الرصيد (ج.م)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($topOutstandingBalances as $student)
+                                    <tr>
+                                        <td>{{ $student->name }}</td>
+                                        <td>{{ $student->grade_level ?? '—' }}</td>
+                                        <td class="text-end">{{ number_format($student->outstanding_fees, 2) }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="3" class="text-center text-muted">لا توجد بيانات مالية متاحة.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12">
+            <div class="card shadow-sm">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-user-plus me-2"></i> آخر الطلاب المسجلين</h5>
+                    <a href="{{ route('students.index') }}" class="btn btn-sm btn-outline-primary">عرض جميع الطلاب</a>
+                </div>
+                <div class="card-body p-0">
+                    <div class="table-responsive">
+                        <table class="table table-hover align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>الطالب</th>
+                                    <th>الكود</th>
+                                    <th>الصف</th>
+                                    <th>الحالة</th>
+                                    <th>تاريخ الإضافة</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($recentStudents as $student)
+                                    <tr>
+                                        <td>{{ $student->name }}</td>
+                                        <td dir="ltr">{{ $student->student_code }}</td>
+                                        <td>{{ $student->grade_level ?? '—' }}</td>
+                                        <td><span class="badge bg-{{ $student->status === 'active' ? 'success' : 'secondary' }}">{{ $student->status_label }}</span></td>
+                                        <td>{{ $student->created_at?->diffForHumans() }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="5" class="text-center text-muted py-4">لا توجد سجلات حديثة.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/show.blade.php
+++ b/modules/Students/Resources/views/show.blade.php
@@ -1,0 +1,137 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تفاصيل الطالب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'ملف الطالب')
+    @section('page-subtitle', 'عرض تفاصيل الطالب والمتابعة الأكاديمية')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">{{ $student->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-body text-center">
+                    <div class="avatar-placeholder avatar-xl bg-primary text-white mx-auto mb-3">
+                        {{ $student->initials }}
+                    </div>
+                    <h4 class="mb-1">{{ $student->name }}</h4>
+                    <p class="text-muted mb-3">{{ $student->grade_level }} {{ $student->classroom ? ' - ' . $student->classroom : '' }}</p>
+                    <span class="badge bg-{{ $student->status === 'active' ? 'success' : ($student->status === 'inactive' ? 'warning' : 'info') }} mb-3">{{ $student->status_label }}</span>
+
+                    <div class="d-grid gap-2">
+                        @can('edit_students')
+                            <a href="{{ route('students.edit', $student) }}" class="btn btn-outline-primary">
+                                <i class="fas fa-edit"></i> تعديل البيانات
+                            </a>
+                        @endcan
+                        @can('delete_students')
+                            <form action="{{ route('students.destroy', $student) }}" method="POST" onsubmit="return confirm('هل أنت متأكد من حذف سجل الطالب؟');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-danger"><i class="fas fa-trash"></i> حذف الطالب</button>
+                            </form>
+                        @endcan
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-id-card me-2"></i> المعلومات الأساسية</h5>
+                    <span class="text-muted" dir="ltr">{{ $student->student_code }}</span>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <strong>الاسم بالإنجليزية:</strong>
+                            <div class="text-muted">{{ $student->english_name ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>الجنس:</strong>
+                            <div class="text-muted">{{ $student->gender_label ?? 'غير محدد' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>تاريخ الميلاد:</strong>
+                            <div class="text-muted">{{ $student->birth_date ? $student->birth_date->format('Y-m-d') : '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>العمر:</strong>
+                            <div class="text-muted">{{ $student->age ? $student->age . ' سنة' : '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>الرقم القومي:</strong>
+                            <div class="text-muted" dir="ltr">{{ $student->national_id ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>تاريخ القبول:</strong>
+                            <div class="text-muted">{{ $student->enrollment_date ? $student->enrollment_date->format('Y-m-d') : '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>البريد الإلكتروني:</strong>
+                            <div class="text-muted" dir="ltr">{{ $student->email ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>رقم الجوال:</strong>
+                            <div class="text-muted" dir="ltr">{{ $student->phone ?? '—' }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fas fa-users me-2"></i> بيانات ولي الأمر</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <strong>اسم ولي الأمر:</strong>
+                            <div class="text-muted">{{ $student->guardian_name ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>صلة القرابة:</strong>
+                            <div class="text-muted">{{ $student->guardian_relationship ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>هاتف ولي الأمر:</strong>
+                            <div class="text-muted" dir="ltr">{{ $student->guardian_phone ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <strong>وسيلة المواصلات:</strong>
+                            <div class="text-muted">{{ $student->transportation_method ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-12">
+                            <strong>العنوان:</strong>
+                            <div class="text-muted">{{ $student->address ? $student->address . '، ' . $student->city : ($student->city ?? '—') }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0"><i class="fas fa-file-medical me-2"></i> ملاحظات إضافية</h5>
+                    <span class="badge bg-secondary">الرصيد المستحق: {{ number_format($student->outstanding_fees, 2) }} ج.م</span>
+                </div>
+                <div class="card-body">
+                    <div class="mb-3">
+                        <strong>ملاحظات طبية:</strong>
+                        <p class="text-muted mb-0">{{ $student->medical_notes ? nl2br(e($student->medical_notes)) : 'لا توجد ملاحظات طبية.' }}</p>
+                    </div>
+                    <div>
+                        <strong>ملاحظات إدارية:</strong>
+                        <p class="text-muted mb-0">{{ $student->notes ? nl2br(e($student->notes)) : 'لا توجد ملاحظات إضافية.' }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Routes/web.php
+++ b/modules/Students/Routes/web.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Students\Http\Controllers\StudentController;
+
+Route::middleware(['web', 'auth'])
+    ->prefix('students')
+    ->name('students.')
+    ->group(function () {
+        Route::get('/', [StudentController::class, 'index'])
+            ->name('index')
+            ->middleware('can:view_students');
+
+        Route::get('/create', [StudentController::class, 'create'])
+            ->name('create')
+            ->middleware('can:create_students');
+
+        Route::post('/', [StudentController::class, 'store'])
+            ->name('store')
+            ->middleware('can:create_students');
+
+        Route::get('/reports', [StudentController::class, 'reports'])
+            ->name('reports')
+            ->middleware('can:view_students');
+
+        Route::get('/{student}', [StudentController::class, 'show'])
+            ->name('show')
+            ->middleware('can:view_students');
+
+        Route::get('/{student}/edit', [StudentController::class, 'edit'])
+            ->name('edit')
+            ->middleware('can:edit_students');
+
+        Route::put('/{student}', [StudentController::class, 'update'])
+            ->name('update')
+            ->middleware('can:edit_students');
+
+        Route::delete('/{student}', [StudentController::class, 'destroy'])
+            ->name('destroy')
+            ->middleware('can:delete_students');
+    });

--- a/modules/Students/module.json
+++ b/modules/Students/module.json
@@ -1,0 +1,10 @@
+{
+    "name": "Students",
+    "alias": "students",
+    "description": "إدارة بيانات الطلاب وسجلاتهم الدراسية.",
+    "keywords": ["students", "enrollment", "records"],
+    "priority": 10,
+    "providers": [
+        "Modules\\Students\\Providers\\StudentsServiceProvider"
+    ]
+}

--- a/modules/Subjects/Http/Controllers/SubjectController.php
+++ b/modules/Subjects/Http/Controllers/SubjectController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Modules\Subjects\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Subject;
+use App\Models\Teacher;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Modules\Subjects\Http\Requests\StoreSubjectRequest;
+use Modules\Subjects\Http\Requests\UpdateSubjectRequest;
+
+class SubjectController extends Controller
+{
+    public function index(Request $request): View|ViewFactory
+    {
+        $subjects = Subject::query()
+            ->with('teacher')
+            ->latest()
+            ->filter($request->only(['search', 'grade_level']))
+            ->paginate()
+            ->withQueryString();
+
+        return view('subjects::index', [
+            'subjects' => $subjects,
+            'filters' => $request->only(['search', 'grade_level']),
+            'teachers' => Teacher::orderBy('name')->get(),
+        ]);
+    }
+
+    public function create(): View|ViewFactory
+    {
+        return view('subjects::create', [
+            'subject' => new Subject(),
+            'teachers' => Teacher::orderBy('name')->get(),
+        ]);
+    }
+
+    public function store(StoreSubjectRequest $request): RedirectResponse
+    {
+        $subject = Subject::create($request->validated());
+
+        return redirect()->route('subjects.show', $subject)->with('success', 'تم إنشاء المادة بنجاح.');
+    }
+
+    public function show(Subject $subject): View|ViewFactory
+    {
+        $subject->load('teacher');
+
+        return view('subjects::show', [
+            'subject' => $subject,
+        ]);
+    }
+
+    public function edit(Subject $subject): View|ViewFactory
+    {
+        return view('subjects::edit', [
+            'subject' => $subject,
+            'teachers' => Teacher::orderBy('name')->get(),
+        ]);
+    }
+
+    public function update(UpdateSubjectRequest $request, Subject $subject): RedirectResponse
+    {
+        $subject->update($request->validated());
+
+        return redirect()->route('subjects.show', $subject)->with('success', 'تم تحديث بيانات المادة.');
+    }
+
+    public function destroy(Subject $subject): RedirectResponse
+    {
+        $subject->delete();
+
+        return redirect()->route('subjects.index')->with('success', 'تم حذف المادة.');
+    }
+}

--- a/modules/Subjects/Http/Requests/StoreSubjectRequest.php
+++ b/modules/Subjects/Http/Requests/StoreSubjectRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Modules\Subjects\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSubjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code' => ['required', 'string', 'max:20', 'unique:subjects,code'],
+            'name' => ['required', 'string', 'max:255'],
+            'grade_level' => ['required', 'string', 'max:100'],
+            'teacher_id' => ['nullable', 'exists:teachers,id'],
+            'weekly_hours' => ['nullable', 'integer', 'min:0'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/modules/Subjects/Http/Requests/UpdateSubjectRequest.php
+++ b/modules/Subjects/Http/Requests/UpdateSubjectRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\Subjects\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateSubjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $subjectId = $this->route('subject')?->id ?? null;
+
+        return [
+            'code' => ['required', 'string', 'max:20', Rule::unique('subjects', 'code')->ignore($subjectId)],
+            'name' => ['required', 'string', 'max:255'],
+            'grade_level' => ['required', 'string', 'max:100'],
+            'teacher_id' => ['nullable', 'exists:teachers,id'],
+            'weekly_hours' => ['nullable', 'integer', 'min:0'],
+            'description' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/modules/Subjects/Providers/SubjectsServiceProvider.php
+++ b/modules/Subjects/Providers/SubjectsServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Subjects\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class SubjectsServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/../Routes/web.php');
+        $this->loadViewsFrom(__DIR__.'/../Resources/views', 'subjects');
+        $this->publishes([
+            __DIR__.'/../Resources/views' => resource_path('views/vendor/subjects'),
+        ], 'subjects-views');
+    }
+}

--- a/modules/Subjects/Resources/views/_form.blade.php
+++ b/modules/Subjects/Resources/views/_form.blade.php
@@ -1,0 +1,54 @@
+@csrf
+<div class="row g-3">
+    <div class="col-md-4">
+        <label class="form-label">كود المادة</label>
+        <input type="text" name="code" class="form-control" value="{{ old('code', $subject->code) }}" required>
+        @error('code')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">اسم المادة</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', $subject->name) }}" required>
+        @error('name')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">المرحلة الدراسية</label>
+        <input type="text" name="grade_level" class="form-control" value="{{ old('grade_level', $subject->grade_level) }}" required>
+        @error('grade_level')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">المعلم المسؤول</label>
+        <select name="teacher_id" class="form-select">
+            <option value="">—</option>
+            @foreach($teachers as $teacher)
+                <option value="{{ $teacher->id }}" @selected(old('teacher_id', $subject->teacher_id) == $teacher->id)>{{ $teacher->name }}</option>
+            @endforeach
+        </select>
+        @error('teacher_id')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">ساعات أسبوعية</label>
+        <input type="number" name="weekly_hours" class="form-control" value="{{ old('weekly_hours', $subject->weekly_hours) }}">
+        @error('weekly_hours')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-12">
+        <label class="form-label">الوصف</label>
+        <textarea name="description" rows="4" class="form-control">{{ old('description', $subject->description) }}</textarea>
+        @error('description')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+</div>
+<div class="mt-3 d-flex justify-content-between">
+    <a href="{{ route('subjects.index') }}" class="btn btn-link">عودة</a>
+    <button class="btn btn-success">حفظ</button>
+</div>

--- a/modules/Subjects/Resources/views/create.blade.php
+++ b/modules/Subjects/Resources/views/create.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-3">إضافة مادة جديدة</h1>
+    <div class="card">
+        <form method="post" action="{{ route('subjects.store') }}" class="card-body">
+            @include('subjects::_form')
+        </form>
+    </div>
+</div>
+@endsection

--- a/modules/Subjects/Resources/views/edit.blade.php
+++ b/modules/Subjects/Resources/views/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-3">تعديل المادة</h1>
+    <div class="card">
+        <form method="post" action="{{ route('subjects.update', $subject) }}" class="card-body">
+            @method('put')
+            @include('subjects::_form')
+        </form>
+    </div>
+</div>
+@endsection

--- a/modules/Subjects/Resources/views/index.blade.php
+++ b/modules/Subjects/Resources/views/index.blade.php
@@ -1,0 +1,69 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3">المواد الدراسية</h1>
+        <a href="{{ route('subjects.create') }}" class="btn btn-primary">إضافة مادة</a>
+    </div>
+
+    <form method="get" class="card card-body mb-3">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-6">
+                <label class="form-label">بحث</label>
+                <input type="text" name="search" value="{{ $filters['search'] ?? '' }}" class="form-control" placeholder="اسم المادة أو الكود">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">المرحلة</label>
+                <input type="text" name="grade_level" value="{{ $filters['grade_level'] ?? '' }}" class="form-control">
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-outline-secondary w-100">تطبيق</button>
+            </div>
+        </div>
+    </form>
+
+    <div class="card">
+        <div class="card-body table-responsive">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>الكود</th>
+                        <th>الاسم</th>
+                        <th>المرحلة</th>
+                        <th>المعلم</th>
+                        <th>ساعات أسبوعية</th>
+                        <th class="text-end">إجراءات</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($subjects as $subject)
+                        <tr>
+                            <td>{{ $subject->code }}</td>
+                            <td><a href="{{ route('subjects.show', $subject) }}">{{ $subject->name }}</a></td>
+                            <td>{{ $subject->grade_level }}</td>
+                            <td>{{ $subject->teacher?->name ?? '—' }}</td>
+                            <td>{{ $subject->weekly_hours }}</td>
+                            <td class="text-end">
+                                <a href="{{ route('subjects.edit', $subject) }}" class="btn btn-sm btn-outline-primary">تعديل</a>
+                                <form method="post" action="{{ route('subjects.destroy', $subject) }}" class="d-inline" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                                    @csrf
+                                    @method('delete')
+                                    <button class="btn btn-sm btn-outline-danger">حذف</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">لا توجد مواد مسجلة</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            {{ $subjects->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/modules/Subjects/Resources/views/show.blade.php
+++ b/modules/Subjects/Resources/views/show.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h1 class="h3 mb-0">{{ $subject->name }}</h1>
+            <div class="text-muted">{{ $subject->code }} • {{ $subject->grade_level }}</div>
+        </div>
+        <div class="btn-group">
+            <a href="{{ route('subjects.edit', $subject) }}" class="btn btn-outline-primary">تعديل</a>
+            <form method="post" action="{{ route('subjects.destroy', $subject) }}" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                @csrf
+                @method('delete')
+                <button class="btn btn-outline-danger">حذف</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">معلومات المادة</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">المعلم</dt>
+                        <dd class="col-sm-8">{{ $subject->teacher?->name ?? '—' }}</dd>
+                        <dt class="col-sm-4">الساعات الأسبوعية</dt>
+                        <dd class="col-sm-8">{{ $subject->weekly_hours ?? '—' }}</dd>
+                        <dt class="col-sm-4">آخر تحديث</dt>
+                        <dd class="col-sm-8">{{ optional($subject->updated_at)->diffForHumans() }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">الوصف</div>
+                <div class="card-body">
+                    {{ $subject->description ?? 'لا يوجد وصف' }}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        <a href="{{ route('subjects.index') }}" class="btn btn-link">عودة للقائمة</a>
+    </div>
+</div>
+@endsection

--- a/modules/Subjects/Routes/web.php
+++ b/modules/Subjects/Routes/web.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Subjects\Http\Controllers\SubjectController;
+
+Route::middleware(['web', 'auth'])
+    ->prefix('subjects')
+    ->name('subjects.')
+    ->group(function () {
+        Route::get('/', [SubjectController::class, 'index'])
+            ->name('index')
+            ->middleware('can:view_subjects');
+
+        Route::get('/create', [SubjectController::class, 'create'])
+            ->name('create')
+            ->middleware('can:create_subjects');
+
+        Route::post('/', [SubjectController::class, 'store'])
+            ->name('store')
+            ->middleware('can:create_subjects');
+
+        Route::get('/{subject}', [SubjectController::class, 'show'])
+            ->name('show')
+            ->middleware('can:view_subjects');
+
+        Route::get('/{subject}/edit', [SubjectController::class, 'edit'])
+            ->name('edit')
+            ->middleware('can:edit_subjects');
+
+        Route::put('/{subject}', [SubjectController::class, 'update'])
+            ->name('update')
+            ->middleware('can:edit_subjects');
+
+        Route::delete('/{subject}', [SubjectController::class, 'destroy'])
+            ->name('destroy')
+            ->middleware('can:delete_subjects');
+    });

--- a/modules/Subjects/module.json
+++ b/modules/Subjects/module.json
@@ -1,0 +1,8 @@
+{
+    "name": "Subjects",
+    "alias": "subjects",
+    "description": "إدارة المواد الدراسية",
+    "providers": [
+        "Modules\\Subjects\\Providers\\SubjectsServiceProvider"
+    ]
+}

--- a/modules/Teachers/Http/Controllers/TeacherController.php
+++ b/modules/Teachers/Http/Controllers/TeacherController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Modules\Teachers\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Teacher;
+use Illuminate\Contracts\View\Factory as ViewFactory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Modules\Teachers\Http\Requests\StoreTeacherRequest;
+use Modules\Teachers\Http\Requests\UpdateTeacherRequest;
+
+class TeacherController extends Controller
+{
+    public function index(Request $request): View|ViewFactory
+    {
+        $teachers = Teacher::query()
+            ->latest()
+            ->filter($request->only(['search', 'status']))
+            ->paginate()
+            ->withQueryString();
+
+        return view('teachers::index', [
+            'teachers' => $teachers,
+            'filters' => $request->only(['search', 'status']),
+            'statuses' => Teacher::STATUSES,
+        ]);
+    }
+
+    public function create(): View|ViewFactory
+    {
+        return view('teachers::create', [
+            'teacher' => new Teacher([
+                'status' => 'active',
+                'employee_code' => Teacher::generateEmployeeCode(),
+            ]),
+            'statuses' => Teacher::STATUSES,
+        ]);
+    }
+
+    public function store(StoreTeacherRequest $request): RedirectResponse
+    {
+        $teacher = Teacher::create($request->validated());
+
+        return redirect()
+            ->route('teachers.show', $teacher)
+            ->with('success', 'تم إضافة المعلم بنجاح.');
+    }
+
+    public function show(Teacher $teacher): View|ViewFactory
+    {
+        return view('teachers::show', [
+            'teacher' => $teacher,
+        ]);
+    }
+
+    public function edit(Teacher $teacher): View|ViewFactory
+    {
+        return view('teachers::edit', [
+            'teacher' => $teacher,
+            'statuses' => Teacher::STATUSES,
+        ]);
+    }
+
+    public function update(UpdateTeacherRequest $request, Teacher $teacher): RedirectResponse
+    {
+        $teacher->update($request->validated());
+
+        return redirect()
+            ->route('teachers.show', $teacher)
+            ->with('success', 'تم تحديث بيانات المعلم.');
+    }
+
+    public function destroy(Teacher $teacher): RedirectResponse
+    {
+        $teacher->delete();
+
+        return redirect()
+            ->route('teachers.index')
+            ->with('success', 'تم حذف المعلم.');
+    }
+}

--- a/modules/Teachers/Http/Requests/StoreTeacherRequest.php
+++ b/modules/Teachers/Http/Requests/StoreTeacherRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Modules\Teachers\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Models\Teacher;
+
+class StoreTeacherRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'employee_code' => ['nullable', 'string', 'max:20', 'unique:teachers,employee_code'],
+            'name' => ['required', 'string', 'max:255'],
+            'english_name' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255', 'unique:teachers,email'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'specialization' => ['nullable', 'string', 'max:255'],
+            'hire_date' => ['nullable', 'date'],
+            'salary' => ['nullable', 'numeric', 'min:0'],
+            'status' => ['required', 'string', 'in:'.implode(',', array_keys(Teacher::STATUSES))],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    public function prepareForValidation(): void
+    {
+        if (! $this->filled('employee_code')) {
+            $this->merge([
+                'employee_code' => Teacher::generateEmployeeCode(),
+            ]);
+        }
+    }
+}

--- a/modules/Teachers/Http/Requests/UpdateTeacherRequest.php
+++ b/modules/Teachers/Http/Requests/UpdateTeacherRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\Teachers\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use App\Models\Teacher;
+
+class UpdateTeacherRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $teacherId = $this->route('teacher')?->id ?? null;
+
+        return [
+            'employee_code' => ['required', 'string', 'max:20', Rule::unique('teachers', 'employee_code')->ignore($teacherId)],
+            'name' => ['required', 'string', 'max:255'],
+            'english_name' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255', Rule::unique('teachers', 'email')->ignore($teacherId)],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'specialization' => ['nullable', 'string', 'max:255'],
+            'hire_date' => ['nullable', 'date'],
+            'salary' => ['nullable', 'numeric', 'min:0'],
+            'status' => ['required', 'string', 'in:'.implode(',', array_keys(Teacher::STATUSES))],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/modules/Teachers/Providers/TeachersServiceProvider.php
+++ b/modules/Teachers/Providers/TeachersServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Teachers\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class TeachersServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        $this->loadRoutesFrom(__DIR__.'/../Routes/web.php');
+        $this->loadViewsFrom(__DIR__.'/../Resources/views', 'teachers');
+        $this->publishes([
+            __DIR__.'/../Resources/views' => resource_path('views/vendor/teachers'),
+        ], 'teachers-views');
+    }
+}

--- a/modules/Teachers/Resources/views/_form.blade.php
+++ b/modules/Teachers/Resources/views/_form.blade.php
@@ -1,0 +1,81 @@
+@csrf
+<div class="row g-3">
+    <div class="col-md-4">
+        <label class="form-label">كود الموظف</label>
+        <input type="text" name="employee_code" class="form-control" value="{{ old('employee_code', $teacher->employee_code) }}">
+        @error('employee_code')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">الاسم بالعربية</label>
+        <input type="text" name="name" class="form-control" value="{{ old('name', $teacher->name) }}" required>
+        @error('name')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">الاسم بالإنجليزية</label>
+        <input type="text" name="english_name" class="form-control" value="{{ old('english_name', $teacher->english_name) }}">
+        @error('english_name')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">البريد الإلكتروني</label>
+        <input type="email" name="email" class="form-control" value="{{ old('email', $teacher->email) }}">
+        @error('email')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">رقم الجوال</label>
+        <input type="text" name="phone" class="form-control" value="{{ old('phone', $teacher->phone) }}">
+        @error('phone')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">التخصص</label>
+        <input type="text" name="specialization" class="form-control" value="{{ old('specialization', $teacher->specialization) }}">
+        @error('specialization')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">تاريخ التعيين</label>
+        <input type="date" name="hire_date" class="form-control" value="{{ old('hire_date', optional($teacher->hire_date)->format('Y-m-d')) }}">
+        @error('hire_date')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">الراتب الشهري</label>
+        <input type="number" step="0.01" name="salary" class="form-control" value="{{ old('salary', $teacher->salary) }}">
+        @error('salary')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">الحالة</label>
+        <select name="status" class="form-select">
+            @foreach($statuses as $key => $label)
+                <option value="{{ $key }}" @selected(old('status', $teacher->status) === $key)>{{ $label }}</option>
+            @endforeach
+        </select>
+        @error('status')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-12">
+        <label class="form-label">ملاحظات</label>
+        <textarea name="notes" rows="4" class="form-control">{{ old('notes', $teacher->notes) }}</textarea>
+        @error('notes')
+            <div class="text-danger small">{{ $message }}</div>
+        @enderror
+    </div>
+</div>
+<div class="mt-3 d-flex justify-content-between">
+    <a href="{{ route('teachers.index') }}" class="btn btn-link">عودة</a>
+    <button class="btn btn-success">حفظ</button>
+</div>

--- a/modules/Teachers/Resources/views/create.blade.php
+++ b/modules/Teachers/Resources/views/create.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-3">إضافة معلم جديد</h1>
+    <div class="card">
+        <form method="post" action="{{ route('teachers.store') }}" class="card-body">
+            @include('teachers::_form')
+        </form>
+    </div>
+</div>
+@endsection

--- a/modules/Teachers/Resources/views/edit.blade.php
+++ b/modules/Teachers/Resources/views/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1 class="h3 mb-3">تعديل بيانات المعلم</h1>
+    <div class="card">
+        <form method="post" action="{{ route('teachers.update', $teacher) }}" class="card-body">
+            @method('put')
+            @include('teachers::_form')
+        </form>
+    </div>
+</div>
+@endsection

--- a/modules/Teachers/Resources/views/index.blade.php
+++ b/modules/Teachers/Resources/views/index.blade.php
@@ -1,0 +1,77 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3">المعلمون</h1>
+        <a href="{{ route('teachers.create') }}" class="btn btn-primary">إضافة معلم</a>
+    </div>
+
+    <form method="get" class="card card-body mb-3">
+        <div class="row g-2 align-items-end">
+            <div class="col-md-4">
+                <label class="form-label">بحث</label>
+                <input type="text" name="search" value="{{ $filters['search'] ?? '' }}" class="form-control" placeholder="اسم المعلم أو الكود">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">الحالة</label>
+                <select name="status" class="form-select">
+                    <option value="">الكل</option>
+                    @foreach($statuses as $key => $label)
+                        <option value="{{ $key }}" @selected(($filters['status'] ?? '') === $key)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-md-4">
+                <button class="btn btn-outline-secondary">تطبيق</button>
+            </div>
+        </div>
+    </form>
+
+    <div class="card">
+        <div class="card-body table-responsive">
+            <table class="table table-striped align-middle">
+                <thead>
+                    <tr>
+                        <th>الكود</th>
+                        <th>الاسم</th>
+                        <th>التخصص</th>
+                        <th>الهاتف</th>
+                        <th>الحالة</th>
+                        <th class="text-end">إجراءات</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($teachers as $teacher)
+                        <tr>
+                            <td>{{ $teacher->employee_code }}</td>
+                            <td>
+                                <a href="{{ route('teachers.show', $teacher) }}">{{ $teacher->name }}</a>
+                                <div class="text-muted small">{{ $teacher->english_name }}</div>
+                            </td>
+                            <td>{{ $teacher->specialization }}</td>
+                            <td>{{ $teacher->phone }}</td>
+                            <td>{{ $teacher->status_label }}</td>
+                            <td class="text-end">
+                                <a href="{{ route('teachers.edit', $teacher) }}" class="btn btn-sm btn-outline-primary">تعديل</a>
+                                <form method="post" action="{{ route('teachers.destroy', $teacher) }}" class="d-inline" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                                    @csrf
+                                    @method('delete')
+                                    <button class="btn btn-sm btn-outline-danger">حذف</button>
+                                </form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">لا توجد سجلات</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            {{ $teachers->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/modules/Teachers/Resources/views/show.blade.php
+++ b/modules/Teachers/Resources/views/show.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h1 class="h3 mb-0">{{ $teacher->name }}</h1>
+            <div class="text-muted">{{ $teacher->employee_code }}</div>
+        </div>
+        <div class="btn-group">
+            <a href="{{ route('teachers.edit', $teacher) }}" class="btn btn-outline-primary">تعديل</a>
+            <form method="post" action="{{ route('teachers.destroy', $teacher) }}" onsubmit="return confirm('هل أنت متأكد من الحذف؟');">
+                @csrf
+                @method('delete')
+                <button class="btn btn-outline-danger">حذف</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">البيانات الأساسية</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">الاسم الإنجليزي</dt>
+                        <dd class="col-sm-8">{{ $teacher->english_name ?? '—' }}</dd>
+                        <dt class="col-sm-4">البريد الإلكتروني</dt>
+                        <dd class="col-sm-8">{{ $teacher->email ?? '—' }}</dd>
+                        <dt class="col-sm-4">الهاتف</dt>
+                        <dd class="col-sm-8">{{ $teacher->phone ?? '—' }}</dd>
+                        <dt class="col-sm-4">التخصص</dt>
+                        <dd class="col-sm-8">{{ $teacher->specialization ?? '—' }}</dd>
+                        <dt class="col-sm-4">الحالة</dt>
+                        <dd class="col-sm-8">{{ $teacher->status_label }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card h-100">
+                <div class="card-header">بيانات وظيفية</div>
+                <div class="card-body">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">تاريخ التعيين</dt>
+                        <dd class="col-sm-8">{{ optional($teacher->hire_date)->format('Y-m-d') ?? '—' }}</dd>
+                        <dt class="col-sm-4">الراتب</dt>
+                        <dd class="col-sm-8">{{ number_format($teacher->salary, 2) }} ر.س</dd>
+                        <dt class="col-sm-4">ملاحظات</dt>
+                        <dd class="col-sm-8">{{ $teacher->notes ?? '—' }}</dd>
+                        <dt class="col-sm-4">آخر تحديث</dt>
+                        <dd class="col-sm-8">{{ optional($teacher->updated_at)->diffForHumans() }}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-3">
+        <a href="{{ route('teachers.index') }}" class="btn btn-link">عودة للقائمة</a>
+    </div>
+</div>
+@endsection

--- a/modules/Teachers/Routes/web.php
+++ b/modules/Teachers/Routes/web.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Teachers\Http\Controllers\TeacherController;
+
+Route::middleware(['web', 'auth'])
+    ->prefix('teachers')
+    ->name('teachers.')
+    ->group(function () {
+        Route::get('/', [TeacherController::class, 'index'])
+            ->name('index')
+            ->middleware('can:view_teachers');
+
+        Route::get('/create', [TeacherController::class, 'create'])
+            ->name('create')
+            ->middleware('can:create_teachers');
+
+        Route::post('/', [TeacherController::class, 'store'])
+            ->name('store')
+            ->middleware('can:create_teachers');
+
+        Route::get('/{teacher}', [TeacherController::class, 'show'])
+            ->name('show')
+            ->middleware('can:view_teachers');
+
+        Route::get('/{teacher}/edit', [TeacherController::class, 'edit'])
+            ->name('edit')
+            ->middleware('can:edit_teachers');
+
+        Route::put('/{teacher}', [TeacherController::class, 'update'])
+            ->name('update')
+            ->middleware('can:edit_teachers');
+
+        Route::delete('/{teacher}', [TeacherController::class, 'destroy'])
+            ->name('destroy')
+            ->middleware('can:delete_teachers');
+    });

--- a/modules/Teachers/module.json
+++ b/modules/Teachers/module.json
@@ -1,0 +1,8 @@
+{
+    "name": "Teachers",
+    "alias": "teachers",
+    "description": "إدارة المعلمين",
+    "providers": [
+        "Modules\\Teachers\\Providers\\TeachersServiceProvider"
+    ]
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,3 +1,7 @@
 {
-    "Users": true
+    "Users": true,
+    "Students": true,
+    "Teachers": true,
+    "Classes": true,
+    "Subjects": true
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,42 +18,6 @@ Route::middleware(['auth'])->group(function () {
     // Main Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
-    // Students Routes
-    Route::prefix('students')->name('students.')->group(function () {
-        Route::get('/', function() { return view('students.index'); })->name('index')->middleware('can:view_students');
-        Route::get('/create', function() { return view('students.create'); })->name('create')->middleware('can:create_students');
-        Route::get('/{student}', function() { return view('students.show'); })->name('show')->middleware('can:view_students');
-        Route::get('/{student}/edit', function() { return view('students.edit'); })->name('edit')->middleware('can:edit_students');
-        Route::get('/reports', function() { return view('students.reports'); })->name('reports')->middleware('can:view_students');
-    });
-
-    // Teachers Routes
-    Route::prefix('teachers')->name('teachers.')->group(function () {
-        Route::get('/', function() { return view('teachers.index'); })->name('index')->middleware('can:view_teachers');
-        Route::get('/create', function() { return view('teachers.create'); })->name('create')->middleware('can:create_teachers');
-        Route::get('/{teacher}', function() { return view('teachers.show'); })->name('show')->middleware('can:view_teachers');
-        Route::get('/{teacher}/edit', function() { return view('teachers.edit'); })->name('edit')->middleware('can:edit_teachers');
-        Route::get('/schedules', function() { return view('teachers.schedules'); })->name('schedules')->middleware('can:view_teachers');
-    });
-
-    // Classes Routes
-    Route::prefix('classes')->name('classes.')->group(function () {
-        Route::get('/', function() { return view('classes.index'); })->name('index')->middleware('can:view_classes');
-        Route::get('/create', function() { return view('classes.create'); })->name('create')->middleware('can:create_classes');
-        Route::get('/{class}', function() { return view('classes.show'); })->name('show')->middleware('can:view_classes');
-        Route::get('/{class}/edit', function() { return view('classes.edit'); })->name('edit')->middleware('can:edit_classes');
-        Route::get('/timetables', function() { return view('classes.timetables'); })->name('timetables')->middleware('can:view_timetable');
-    });
-
-    // Subjects Routes
-    Route::prefix('subjects')->name('subjects.')->group(function () {
-        Route::get('/', function() { return view('subjects.index'); })->name('index')->middleware('can:view_subjects');
-        Route::get('/create', function() { return view('subjects.create'); })->name('create')->middleware('can:create_subjects');
-        Route::get('/{subject}', function() { return view('subjects.show'); })->name('show')->middleware('can:view_subjects');
-        Route::get('/{subject}/edit', function() { return view('subjects.edit'); })->name('edit')->middleware('can:edit_subjects');
-        Route::get('/assignments', function() { return view('subjects.assignments'); })->name('assignments')->middleware('can:view_subjects');
-    });
-
     // Attendance Routes
     Route::prefix('attendance')->name('attendance.')->group(function () {
         Route::get('/daily', function() { return view('attendance.daily'); })->name('daily')->middleware('can:view_attendance');


### PR DESCRIPTION
## Summary
- add teacher domain model, migration, and management module with CRUD flows and Bootstrap views
- add school class entity tied to homeroom teachers with full module routing, forms, and pages
- add subject catalogue module linking instructors, update module registry, and remove placeholder routes

## Testing
- php -l modules/Teachers/Http/Controllers/TeacherController.php
- php -l modules/Classes/Http/Controllers/ClassController.php
- php -l modules/Subjects/Http/Controllers/SubjectController.php
- php -l app/Models/Teacher.php
- php -l app/Models/SchoolClass.php
- php -l app/Models/Subject.php

------
https://chatgpt.com/codex/tasks/task_e_68db238662b8832f96198286050f7b86