### PR TITLE
Implement full students and teachers management modules

### DIFF
--- a/app/Models/StudentProfile.php
+++ b/app/Models/StudentProfile.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+class StudentProfile extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'user_id',
+        'student_code',
+        'gender',
+        'date_of_birth',
+        'grade_level',
+        'classroom',
+        'enrollment_date',
+        'guardian_name',
+        'guardian_phone',
+        'address',
+        'notes',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'date_of_birth' => 'date',
+        'enrollment_date' => 'date',
+    ];
+
+    /**
+     * Get the owning user.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Accessor for formatted date of birth.
+     */
+    public function getFormattedBirthDateAttribute(): ?string
+    {
+        return $this->date_of_birth
+            ? Carbon::parse($this->date_of_birth)->translatedFormat('d F Y')
+            : null;
+    }
+
+    /**
+     * Accessor for formatted enrollment date.
+     */
+    public function getFormattedEnrollmentDateAttribute(): ?string
+    {
+        return $this->enrollment_date
+            ? Carbon::parse($this->enrollment_date)->translatedFormat('d F Y')
+            : null;
+    }
+}

--- a/app/Models/TeacherProfile.php
+++ b/app/Models/TeacherProfile.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+class TeacherProfile extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'user_id',
+        'teacher_code',
+        'gender',
+        'specialization',
+        'qualification',
+        'hire_date',
+        'experience_years',
+        'phone_secondary',
+        'address',
+        'subjects',
+        'office_hours',
+        'notes',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'hire_date' => 'date',
+        'subjects' => 'array',
+    ];
+
+    /**
+     * Get the owning user.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Accessor for formatted hire date.
+     */
+    public function getFormattedHireDateAttribute(): ?string
+    {
+        return $this->hire_date
+            ? Carbon::parse($this->hire_date)->translatedFormat('d F Y')
+            : null;
+    }
+
+    /**
+     * Accessor for subjects list as string.
+     */
+    public function getSubjectsListAttribute(): string
+    {
+        return collect($this->subjects ?? [])
+            ->filter()
+            ->map(fn ($subject) => trim($subject))
+            ->implode('، ');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -113,6 +114,22 @@ class User extends Authenticatable
     public function scopeWithRole($query, $role)
     {
         return $query->role($role);
+    }
+
+    /**
+     * Get the attached student profile.
+     */
+    public function studentProfile(): HasOne
+    {
+        return $this->hasOne(StudentProfile::class);
+    }
+
+    /**
+     * Get the attached teacher profile.
+     */
+    public function teacherProfile(): HasOne
+    {
+        return $this->hasOne(TeacherProfile::class);
     }
 
     /**

--- a/database/migrations/2025_09_02_000001_create_student_profiles_table.php
+++ b/database/migrations/2025_09_02_000001_create_student_profiles_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('student_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('student_code')->nullable()->unique();
+            $table->enum('gender', ['male', 'female'])->nullable();
+            $table->date('date_of_birth')->nullable();
+            $table->string('grade_level')->nullable();
+            $table->string('classroom')->nullable();
+            $table->date('enrollment_date')->nullable();
+            $table->string('guardian_name')->nullable();
+            $table->string('guardian_phone')->nullable();
+            $table->string('address')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('student_profiles');
+    }
+};

--- a/database/migrations/2025_09_02_000002_create_teacher_profiles_table.php
+++ b/database/migrations/2025_09_02_000002_create_teacher_profiles_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teacher_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->string('teacher_code')->nullable()->unique();
+            $table->enum('gender', ['male', 'female'])->nullable();
+            $table->string('specialization')->nullable();
+            $table->string('qualification')->nullable();
+            $table->date('hire_date')->nullable();
+            $table->unsignedTinyInteger('experience_years')->nullable();
+            $table->string('phone_secondary')->nullable();
+            $table->string('address')->nullable();
+            $table->json('subjects')->nullable();
+            $table->string('office_hours')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_profiles');
+    }
+};

--- a/database/seeders/DefaultUsersSeeder.php
+++ b/database/seeders/DefaultUsersSeeder.php
@@ -75,6 +75,7 @@ class DefaultUsersSeeder extends Seeder
                 $role = Role::where('name', $roleName)->first();
                 if ($role) {
                     $user->assignRole($role);
+                    $this->createDefaultProfile($user, $roleName);
                     $this->command->info("✅ {$user->name} - Username: {$user->username} - {$role->display_name}");
                     $count++;
                 } else {
@@ -97,6 +98,39 @@ class DefaultUsersSeeder extends Seeder
             $this->command->info('   Username: parent    - Password: 123456789');
             $this->command->info('   Username: accountant- Password: 123456789');
             $this->command->warn('⚠️  يرجى تغيير كلمات المرور بعد أول تسجيل دخول!');
+        }
+    }
+
+    /**
+     * Create default profile for seeded teacher/student.
+     */
+    protected function createDefaultProfile(User $user, string $roleName): void
+    {
+        if ($roleName === 'student') {
+            $user->studentProfile()->create([
+                'student_code' => 'STU-' . str_pad((string) $user->id, 4, '0', STR_PAD_LEFT),
+                'grade_level' => 'الصف الأول الإعدادي',
+                'classroom' => 'A',
+                'enrollment_date' => now()->subYears(1)->startOfYear(),
+                'guardian_name' => 'محمد علي',
+                'guardian_phone' => '01000000000',
+                'address' => 'مدينة بلقاس - الدقهلية',
+            ]);
+
+            return;
+        }
+
+        if ($roleName === 'teacher') {
+            $user->teacherProfile()->create([
+                'teacher_code' => 'TEA-' . str_pad((string) $user->id, 4, '0', STR_PAD_LEFT),
+                'specialization' => 'اللغة العربية',
+                'qualification' => 'ليسانس تربية',
+                'hire_date' => now()->subYears(5)->startOfYear(),
+                'experience_years' => 5,
+                'subjects' => ['اللغة العربية', 'الخط العربي'],
+                'office_hours' => 'الأحد - الخميس 08:00 ص - 02:00 م',
+                'address' => 'مدينة بلقاس - الدقهلية',
+            ]);
         }
     }
 }

--- a/modules/Students/Http/Controllers/StudentController.php
+++ b/modules/Students/Http/Controllers/StudentController.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace Modules\Students\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\StudentProfile;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
+use Modules\Students\Http\Requests\StoreStudentRequest;
+use Modules\Students\Http\Requests\UpdateStudentRequest;
+
+class StudentController extends Controller
+{
+    /**
+     * Display a listing of the students.
+     */
+    public function index(Request $request): View
+    {
+        $filters = $this->filters($request);
+        $students = $this->filteredStudents($filters);
+
+        $stats = [
+            'total' => User::role('student')->count(),
+            'active' => User::role('student')->where('active', true)->count(),
+            'inactive' => User::role('student')->where('active', false)->count(),
+            'with_guardian' => StudentProfile::whereNotNull('guardian_phone')->count(),
+        ];
+
+        $gradeOptions = $this->gradeOptions();
+        $classrooms = $this->classroomOptions();
+
+        return view('students::index', compact('students', 'filters', 'stats', 'gradeOptions', 'classrooms'));
+    }
+
+    /**
+     * Show the form for creating a new student.
+     */
+    public function create(): View
+    {
+        return view('students::create', [
+            'gradeOptions' => $this->gradeOptions(),
+            'classrooms' => $this->classroomOptions(),
+        ]);
+    }
+
+    /**
+     * Store a newly created student in storage.
+     */
+    public function store(StoreStudentRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $avatarPath = $this->handleAvatarUpload($request);
+
+        $student = User::create([
+            'name' => $data['name'],
+            'username' => $data['username'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'password' => Hash::make($data['password']),
+            'avatar' => $avatarPath,
+            'active' => $request->boolean('active', true),
+        ]);
+
+        $student->assignRole('student');
+
+        $student->studentProfile()->create($this->profilePayload($data));
+
+        return redirect()
+            ->route('students.show', $student)
+            ->with('success', 'تم تسجيل الطالب بنجاح.');
+    }
+
+    /**
+     * Display the specified student.
+     */
+    public function show(User $student): View
+    {
+        $student->load('studentProfile');
+
+        return view('students::show', [
+            'student' => $student,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified student.
+     */
+    public function edit(User $student): View
+    {
+        $student->load('studentProfile');
+
+        return view('students::edit', [
+            'student' => $student,
+            'gradeOptions' => $this->gradeOptions(),
+            'classrooms' => $this->classroomOptions(),
+        ]);
+    }
+
+    /**
+     * Update the specified student in storage.
+     */
+    public function update(UpdateStudentRequest $request, User $student): RedirectResponse
+    {
+        $data = $request->validated();
+        $payload = [
+            'name' => $data['name'],
+            'username' => $data['username'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'active' => $request->boolean('active', true),
+        ];
+
+        if (! empty($data['password'])) {
+            $payload['password'] = Hash::make($data['password']);
+        }
+
+        $avatarPath = $this->handleAvatarUpload($request, $student);
+        if ($avatarPath !== null) {
+            $payload['avatar'] = $avatarPath;
+        }
+
+        $student->update($payload);
+        $student->studentProfile()->updateOrCreate([], $this->profilePayload($data));
+
+        return redirect()
+            ->route('students.show', $student)
+            ->with('success', 'تم تحديث بيانات الطالب بنجاح.');
+    }
+
+    /**
+     * Remove the specified student from storage.
+     */
+    public function destroy(User $student): RedirectResponse
+    {
+        if ($student->is(auth()->user())) {
+            return redirect()
+                ->route('students.index')
+                ->with('error', 'لا يمكنك حذف حسابك الشخصي.');
+        }
+
+        $this->deleteAvatarIfExists($student);
+        $student->delete();
+
+        return redirect()
+            ->route('students.index')
+            ->with('success', 'تم حذف الطالب بنجاح.');
+    }
+
+    /**
+     * Export students as CSV file.
+     */
+    public function export(Request $request)
+    {
+        $this->authorize('export_students');
+
+        $filters = $this->filters($request);
+        $students = $this->filteredStudents($filters, false);
+
+        $filename = 'students-export-' . now()->format('Ymd_His') . '.csv';
+
+        return response()->streamDownload(function () use ($students) {
+            $handle = fopen('php://output', 'w');
+            fprintf($handle, chr(0xEF) . chr(0xBB) . chr(0xBF));
+
+            fputcsv($handle, [
+                'الاسم الكامل',
+                'اسم المستخدم',
+                'البريد الإلكتروني',
+                'رقم الهاتف',
+                'الصف الدراسي',
+                'الفصل',
+                'اسم ولي الأمر',
+                'رقم ولي الأمر',
+                'تاريخ الالتحاق',
+                'الحالة',
+            ]);
+
+            $students->each(function (User $student) use ($handle) {
+                $profile = $student->studentProfile;
+
+                fputcsv($handle, [
+                    $student->name,
+                    $student->username,
+                    $student->email,
+                    $student->phone,
+                    $profile?->grade_level,
+                    $profile?->classroom,
+                    $profile?->guardian_name,
+                    $profile?->guardian_phone,
+                    optional($profile?->enrollment_date)->format('Y-m-d'),
+                    $student->active ? 'نشط' : 'غير نشط',
+                ]);
+            });
+
+            fclose($handle);
+        }, $filename, [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+        ]);
+    }
+
+    /**
+     * Display reports and statistics.
+     */
+    public function reports(): View
+    {
+        $gradeDistribution = StudentProfile::select('grade_level', DB::raw('COUNT(*) as total'))
+            ->whereNotNull('grade_level')
+            ->groupBy('grade_level')
+            ->orderBy('grade_level')
+            ->get();
+
+        $genderDistribution = StudentProfile::select('gender', DB::raw('COUNT(*) as total'))
+            ->whereNotNull('gender')
+            ->groupBy('gender')
+            ->get();
+
+        $enrollmentTrend = StudentProfile::selectRaw('DATE_FORMAT(enrollment_date, "%Y-%m") as month, COUNT(*) as total')
+            ->whereNotNull('enrollment_date')
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get()
+            ->map(function ($row) {
+                return [
+                    'month' => Carbon::createFromFormat('Y-m', $row->month)->translatedFormat('F Y'),
+                    'total' => $row->total,
+                ];
+            });
+
+        return view('students::reports', compact('gradeDistribution', 'genderDistribution', 'enrollmentTrend'));
+    }
+
+    /**
+     * Retrieve filtered students.
+     */
+    protected function filteredStudents(array $filters, bool $paginate = true)
+    {
+        $query = User::query()
+            ->role('student')
+            ->with('studentProfile');
+
+        if (! empty($filters['search'])) {
+            $query->where(function ($q) use ($filters) {
+                $q->where('name', 'like', "%{$filters['search']}%")
+                    ->orWhere('email', 'like', "%{$filters['search']}%")
+                    ->orWhere('username', 'like', "%{$filters['search']}%")
+                    ->orWhere('phone', 'like', "%{$filters['search']}%")
+                    ->orWhereHas('studentProfile', function ($sub) use ($filters) {
+                        $sub->where('guardian_name', 'like', "%{$filters['search']}%")
+                            ->orWhere('guardian_phone', 'like', "%{$filters['search']}%")
+                            ->orWhere('student_code', 'like', "%{$filters['search']}%");
+                    });
+            });
+        }
+
+        if (! empty($filters['grade_level'])) {
+            $query->whereHas('studentProfile', function ($q) use ($filters) {
+                $q->where('grade_level', $filters['grade_level']);
+            });
+        }
+
+        if (! empty($filters['classroom'])) {
+            $query->whereHas('studentProfile', function ($q) use ($filters) {
+                $q->where('classroom', $filters['classroom']);
+            });
+        }
+
+        if (! empty($filters['gender'])) {
+            $query->whereHas('studentProfile', function ($q) use ($filters) {
+                $q->where('gender', $filters['gender']);
+            });
+        }
+
+        if ($filters['status'] !== null) {
+            $query->where('active', (bool) $filters['status']);
+        }
+
+        $query->orderBy('name');
+
+        if ($paginate) {
+            return $query->paginate(12)->withQueryString();
+        }
+
+        return $query->get();
+    }
+
+    /**
+     * Extract filters from request.
+     */
+    protected function filters(Request $request): array
+    {
+        $status = match ($request->input('status')) {
+            'active' => 1,
+            'inactive' => 0,
+            default => null,
+        };
+
+        return [
+            'search' => $request->input('search'),
+            'grade_level' => $request->input('grade_level'),
+            'classroom' => $request->input('classroom'),
+            'gender' => $request->input('gender'),
+            'status' => $status,
+        ];
+    }
+
+    /**
+     * Prepare profile payload from validated data.
+     */
+    protected function profilePayload(array $data): array
+    {
+        return Arr::only($data, [
+            'student_code',
+            'gender',
+            'date_of_birth',
+            'grade_level',
+            'classroom',
+            'enrollment_date',
+            'guardian_name',
+            'guardian_phone',
+            'address',
+            'notes',
+        ]);
+    }
+
+    /**
+     * Handle avatar upload for store/update operations.
+     */
+    protected function handleAvatarUpload(Request $request, ?User $student = null): ?string
+    {
+        if (! $request->hasFile('avatar')) {
+            return $student?->avatar;
+        }
+
+        $avatar = $request->file('avatar');
+        $path = $avatar->store('avatars', 'public');
+
+        if ($student && $student->avatar) {
+            Storage::disk('public')->delete($student->avatar);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Delete stored avatar if exists.
+     */
+    protected function deleteAvatarIfExists(User $student): void
+    {
+        if ($student->avatar) {
+            Storage::disk('public')->delete($student->avatar);
+        }
+    }
+
+    /**
+     * Available grade options.
+     */
+    protected function gradeOptions(): array
+    {
+        return [
+            'رياض الأطفال (KG1)',
+            'رياض الأطفال (KG2)',
+            'الصف الأول الابتدائي',
+            'الصف الثاني الابتدائي',
+            'الصف الثالث الابتدائي',
+            'الصف الرابع الابتدائي',
+            'الصف الخامس الابتدائي',
+            'الصف السادس الابتدائي',
+            'الصف الأول الإعدادي',
+            'الصف الثاني الإعدادي',
+            'الصف الثالث الإعدادي',
+            'الصف الأول الثانوي',
+            'الصف الثاني الثانوي',
+            'الصف الثالث الثانوي',
+        ];
+    }
+
+    /**
+     * Available classroom options.
+     */
+    protected function classroomOptions(): array
+    {
+        return ['A', 'B', 'C', 'D', 'E', 'F'];
+    }
+}

--- a/modules/Students/Http/Requests/StoreStudentRequest.php
+++ b/modules/Students/Http/Requests/StoreStudentRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Modules\Students\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreStudentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create_students') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:255', 'unique:users,username'],
+            'email' => ['nullable', 'email', 'max:255', 'unique:users,email'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'active' => ['sometimes', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
+            'student_code' => ['nullable', 'string', 'max:50', 'unique:student_profiles,student_code'],
+            'gender' => ['nullable', 'in:male,female'],
+            'date_of_birth' => ['nullable', 'date', 'before:today'],
+            'grade_level' => ['nullable', 'string', 'max:120'],
+            'classroom' => ['nullable', 'string', 'max:50'],
+            'enrollment_date' => ['nullable', 'date'],
+            'guardian_name' => ['nullable', 'string', 'max:255'],
+            'guardian_phone' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Custom attributes in Arabic.
+     */
+    public function attributes(): array
+    {
+        return [
+            'name' => 'اسم الطالب',
+            'username' => 'اسم المستخدم',
+            'email' => 'البريد الإلكتروني',
+            'phone' => 'رقم الهاتف',
+            'password' => 'كلمة المرور',
+            'student_code' => 'الرقم التعريفي للطالب',
+            'gender' => 'النوع',
+            'date_of_birth' => 'تاريخ الميلاد',
+            'grade_level' => 'الصف الدراسي',
+            'classroom' => 'الفصل',
+            'enrollment_date' => 'تاريخ الالتحاق',
+            'guardian_name' => 'اسم ولي الأمر',
+            'guardian_phone' => 'هاتف ولي الأمر',
+            'address' => 'العنوان',
+            'notes' => 'الملاحظات',
+        ];
+    }
+}

--- a/modules/Students/Http/Requests/UpdateStudentRequest.php
+++ b/modules/Students/Http/Requests/UpdateStudentRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Modules\Students\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateStudentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('edit_students') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        $studentId = $this->route('student')?->getKey();
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:255', Rule::unique('users', 'username')->ignore($studentId)],
+            'email' => ['nullable', 'email', 'max:255', Rule::unique('users', 'email')->ignore($studentId)],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'active' => ['sometimes', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
+            'student_code' => ['nullable', 'string', 'max:50', Rule::unique('student_profiles', 'student_code')->ignore($studentId, 'user_id')],
+            'gender' => ['nullable', 'in:male,female'],
+            'date_of_birth' => ['nullable', 'date', 'before:today'],
+            'grade_level' => ['nullable', 'string', 'max:120'],
+            'classroom' => ['nullable', 'string', 'max:50'],
+            'enrollment_date' => ['nullable', 'date'],
+            'guardian_name' => ['nullable', 'string', 'max:255'],
+            'guardian_phone' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return (new StoreStudentRequest())->attributes();
+    }
+}

--- a/modules/Students/Providers/StudentsServiceProvider.php
+++ b/modules/Students/Providers/StudentsServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Students\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class StudentsServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $moduleBasePath = __DIR__ . '/../';
+
+        $this->loadRoutesFrom($moduleBasePath . 'Routes/web.php');
+        $this->loadViewsFrom($moduleBasePath . 'Resources/views', 'students');
+    }
+}

--- a/modules/Students/Resources/views/create.blade.php
+++ b/modules/Students/Resources/views/create.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تسجيل طالب جديد - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تسجيل طالب جديد')
+    @section('page-subtitle', 'إضافة بيانات طالب جديد إلى النظام')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">تسجيل طالب</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h5 class="card-title mb-4">بيانات الطالب الأساسية</h5>
+            <form method="POST" action="{{ route('students.store') }}" enctype="multipart/form-data" class="needs-validation" novalidate>
+                @csrf
+                @include('students::partials.form')
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('students.index') }}" class="btn btn-light">إلغاء</a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save"></i> حفظ البيانات
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/edit.blade.php
+++ b/modules/Students/Resources/views/edit.blade.php
@@ -1,0 +1,34 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تعديل بيانات الطالب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تعديل بيانات الطالب')
+    @section('page-subtitle', 'تحديث معلومات الطالب وبيانات ولي الأمر')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">{{ $student->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h5 class="card-title mb-4">بيانات الطالب</h5>
+            <form method="POST" action="{{ route('students.update', $student) }}" enctype="multipart/form-data">
+                @csrf
+                @method('PUT')
+                @include('students::partials.form')
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('students.show', $student) }}" class="btn btn-light">إلغاء</a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save"></i> تحديث البيانات
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/index.blade.php
+++ b/modules/Students/Resources/views/index.blade.php
@@ -1,0 +1,210 @@
+@extends('admin.layouts.master')
+
+@section('title', 'الطلاب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إدارة الطلاب')
+    @section('page-subtitle', 'متابعة بيانات الطلاب والسجلات الدراسية')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item active">الطلاب</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon students"><i class="fas fa-user-graduate"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ $stats['total'] }}</div>
+                    <div class="stat-label">إجمالي الطلاب</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-check"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-success">{{ $stats['active'] }}</div>
+                    <div class="stat-label">طلاب نشطون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-slash"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-danger">{{ $stats['inactive'] }}</div>
+                    <div class="stat-label">طلاب غير نشطين</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon classes"><i class="fas fa-people-group"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ $stats['with_guardian'] }}</div>
+                    <div class="stat-label">طلاب محدثة بيانات ولي الأمر</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
+                <h5 class="mb-0"><i class="fas fa-filter me-2"></i> تصفية الطلاب</h5>
+                <div class="d-flex gap-2">
+                    @can('export_students')
+                        <a href="{{ route('students.export', request()->query()) }}" class="btn btn-outline-primary">
+                            <i class="fas fa-file-export"></i> تصدير CSV
+                        </a>
+                    @endcan
+                    @can('create_students')
+                        <a href="{{ route('students.create') }}" class="btn btn-primary">
+                            <i class="fas fa-user-plus"></i> طالب جديد
+                        </a>
+                    @endcan
+                </div>
+            </div>
+
+            <form method="GET" action="{{ route('students.index') }}" class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">بحث</label>
+                    <input type="text" name="search" value="{{ $filters['search'] }}" class="form-control" placeholder="ابحث بالاسم أو البريد أو ولي الأمر">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">الصف الدراسي</label>
+                    <select name="grade_level" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($gradeOptions as $grade)
+                            <option value="{{ $grade }}" @selected($filters['grade_level'] === $grade)>{{ $grade }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">الفصل</label>
+                    <select name="classroom" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($classrooms as $classroom)
+                            <option value="{{ $classroom }}" @selected($filters['classroom'] === $classroom)>{{ $classroom }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">الجنس</label>
+                    <select name="gender" class="form-select">
+                        <option value="">الكل</option>
+                        <option value="male" @selected($filters['gender'] === 'male')>ذكر</option>
+                        <option value="female" @selected($filters['gender'] === 'female')>أنثى</option>
+                    </select>
+                </div>
+                <div class="col-md-1">
+                    <label class="form-label">الحالة</label>
+                    <select name="status" class="form-select">
+                        <option value="">الكل</option>
+                        <option value="active" @selected(request('status') === 'active')>نشط</option>
+                        <option value="inactive" @selected(request('status') === 'inactive')>موقوف</option>
+                    </select>
+                </div>
+                <div class="col-12 d-flex justify-content-end gap-2">
+                    <a href="{{ route('students.index') }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-rotate-left"></i> إعادة تعيين
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-search"></i> عرض النتائج
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>الطالب</th>
+                            <th>الصف / الفصل</th>
+                            <th>ولي الأمر</th>
+                            <th>رقم الهاتف</th>
+                            <th>تاريخ الالتحاق</th>
+                            <th class="text-center">الحالة</th>
+                            <th class="text-center">إجراءات</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($students as $student)
+                            @php($profile = $student->studentProfile)
+                            <tr>
+                                <td>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <img src="{{ $student->avatar_url }}" alt="{{ $student->name }}" class="rounded-circle" width="42" height="42">
+                                        <div>
+                                            <div class="fw-semibold">{{ $student->name }}</div>
+                                            <small class="text-muted" dir="ltr">{{ $student->username }}</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    <span class="badge bg-primary-subtle text-primary">{{ $profile?->grade_level ?? 'غير محدد' }}</span>
+                                    <div class="text-muted small">{{ $profile?->classroom ? 'فصل ' . $profile->classroom : '' }}</div>
+                                </td>
+                                <td>
+                                    <div>{{ $profile?->guardian_name ?? '—' }}</div>
+                                    <div class="text-muted" dir="ltr">{{ $profile?->guardian_phone ?? '' }}</div>
+                                </td>
+                                <td dir="ltr">{{ $student->phone ?? '—' }}</td>
+                                <td>{{ $profile?->enrollment_date?->translatedFormat('d F Y') ?? '—' }}</td>
+                                <td class="text-center">
+                                    <span class="badge {{ $student->active ? 'bg-success' : 'bg-danger' }}">{{ $student->active ? 'نشط' : 'موقوف' }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <div class="btn-group" role="group">
+                                        @can('view_students')
+                                            <a href="{{ route('students.show', $student) }}" class="btn btn-sm btn-outline-primary" title="عرض">
+                                                <i class="fas fa-eye"></i>
+                                            </a>
+                                        @endcan
+                                        @can('edit_students')
+                                            <a href="{{ route('students.edit', $student) }}" class="btn btn-sm btn-outline-secondary" title="تعديل">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                        @endcan
+                                        @can('delete_students')
+                                            <form action="{{ route('students.destroy', $student) }}" method="POST" onsubmit="return confirm('هل أنت متأكد من حذف الطالب؟');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="حذف">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        @endcan
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center py-4 text-muted">لا توجد بيانات لعرضها.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-end">
+            {{ $students->withQueryString()->links() }}
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/partials/form.blade.php
+++ b/modules/Students/Resources/views/partials/form.blade.php
@@ -1,0 +1,99 @@
+@php($editing = isset($student))
+
+<div class="row g-3">
+    <div class="col-md-6">
+        <label class="form-label">اسم الطالب</label>
+        <input type="text" name="name" value="{{ old('name', $editing ? $student->name : '') }}" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">اسم المستخدم</label>
+        <input type="text" name="username" value="{{ old('username', $editing ? $student->username : '') }}" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">الرقم التعريفي</label>
+        <input type="text" name="student_code" value="{{ old('student_code', $editing ? optional($student->studentProfile)->student_code : '') }}" class="form-control">
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">البريد الإلكتروني</label>
+        <input type="email" name="email" value="{{ old('email', $editing ? $student->email : '') }}" class="form-control">
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">رقم الهاتف</label>
+        <input type="text" name="phone" value="{{ old('phone', $editing ? $student->phone : '') }}" class="form-control">
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">حالة الحساب</label>
+        <select name="active" class="form-select">
+            <option value="1" @selected(old('active', $editing ? $student->active : true))>نشط</option>
+            <option value="0" @selected(old('active', $editing ? ! $student->active : false))>موقوف</option>
+        </select>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">كلمة المرور</label>
+        <input type="password" name="password" class="form-control" @if(! $editing) required @endif placeholder="{{ $editing ? 'اتركها فارغة للحفاظ على الحالية' : '' }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">تأكيد كلمة المرور</label>
+        <input type="password" name="password_confirmation" class="form-control" @if(! $editing) required @endif>
+    </div>
+
+    <div class="col-md-3">
+        <label class="form-label">الصف الدراسي</label>
+        <select name="grade_level" class="form-select">
+            <option value="">اختر الصف</option>
+            @foreach($gradeOptions as $grade)
+                <option value="{{ $grade }}" @selected(old('grade_level', optional($student->studentProfile ?? null)->grade_level) === $grade)>{{ $grade }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">الفصل</label>
+        <select name="classroom" class="form-select">
+            <option value="">اختر الفصل</option>
+            @foreach($classrooms as $classroom)
+                <option value="{{ $classroom }}" @selected(old('classroom', optional($student->studentProfile ?? null)->classroom) === $classroom)>{{ $classroom }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">الجنس</label>
+        <select name="gender" class="form-select">
+            <option value="">غير محدد</option>
+            <option value="male" @selected(old('gender', optional($student->studentProfile ?? null)->gender) === 'male')>ذكر</option>
+            <option value="female" @selected(old('gender', optional($student->studentProfile ?? null)->gender) === 'female')>أنثى</option>
+        </select>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">تاريخ الميلاد</label>
+        <input type="date" name="date_of_birth" value="{{ old('date_of_birth', optional(optional($student->studentProfile ?? null)->date_of_birth)->format('Y-m-d')) }}" class="form-control">
+    </div>
+
+    <div class="col-md-4">
+        <label class="form-label">تاريخ الالتحاق</label>
+        <input type="date" name="enrollment_date" value="{{ old('enrollment_date', optional(optional($student->studentProfile ?? null)->enrollment_date)->format('Y-m-d')) }}" class="form-control">
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">اسم ولي الأمر</label>
+        <input type="text" name="guardian_name" value="{{ old('guardian_name', optional($student->studentProfile ?? null)->guardian_name) }}" class="form-control">
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">هاتف ولي الأمر</label>
+        <input type="text" name="guardian_phone" value="{{ old('guardian_phone', optional($student->studentProfile ?? null)->guardian_phone) }}" class="form-control">
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">العنوان</label>
+        <input type="text" name="address" value="{{ old('address', optional($student->studentProfile ?? null)->address) }}" class="form-control">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">صورة الطالب</label>
+        <input type="file" name="avatar" class="form-control">
+    </div>
+
+    <div class="col-12">
+        <label class="form-label">ملاحظات إضافية</label>
+        <textarea name="notes" rows="3" class="form-control">{{ old('notes', optional($student->studentProfile ?? null)->notes) }}</textarea>
+    </div>
+</div>

--- a/modules/Students/Resources/views/reports.blade.php
+++ b/modules/Students/Resources/views/reports.blade.php
@@ -1,0 +1,108 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تقارير الطلاب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تقارير الطلاب')
+    @section('page-subtitle', 'تحليلات التوزيع والالتحاق للطلاب')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">التقارير</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">توزيع الطلاب حسب النوع</h5>
+                </div>
+                <div class="card-body">
+                    @if($genderDistribution->isEmpty())
+                        <p class="text-muted mb-0">لا توجد بيانات كافية لعرض التوزيع.</p>
+                    @else
+                        <ul class="list-group list-group-flush">
+                            @foreach($genderDistribution as $row)
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    <span>{{ $row->gender === 'male' ? 'طلاب' : 'طالبات' }}</span>
+                                    <span class="badge bg-primary rounded-pill">{{ $row->total }}</span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-8">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">التحاق الطلاب خلال العام</h5>
+                </div>
+                <div class="card-body">
+                    @if($enrollmentTrend->isEmpty())
+                        <p class="text-muted mb-0">لم يتم تسجيل حالات التحاق بعد.</p>
+                    @else
+                        <div class="table-responsive">
+                            <table class="table table-sm">
+                                <thead>
+                                    <tr>
+                                        <th>الشهر</th>
+                                        <th>عدد الطلاب الملتحقين</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($enrollmentTrend as $row)
+                                        <tr>
+                                            <td>{{ $row['month'] }}</td>
+                                            <td>{{ $row['total'] }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mt-4">
+        <div class="card-header bg-white d-flex justify-content-between align-items-center">
+            <h5 class="card-title mb-0">توزيع الطلاب حسب الصفوف</h5>
+            <a href="{{ route('students.index') }}" class="btn btn-sm btn-outline-secondary">
+                <i class="fas fa-arrow-right"></i> الرجوع لقائمة الطلاب
+            </a>
+        </div>
+        <div class="card-body">
+            @if($gradeDistribution->isEmpty())
+                <p class="text-muted mb-0">لا توجد بيانات صفوف متاحة حالياً.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>الصف الدراسي</th>
+                                <th>عدد الطلاب</th>
+                                <th>النسبة المئوية</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @php($total = $gradeDistribution->sum('total'))
+                            @foreach($gradeDistribution as $row)
+                                <tr>
+                                    <td>{{ $row->grade_level }}</td>
+                                    <td>{{ $row->total }}</td>
+                                    <td>{{ $total ? number_format(($row->total / $total) * 100, 1) : 0 }}%</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Resources/views/show.blade.php
+++ b/modules/Students/Resources/views/show.blade.php
@@ -1,0 +1,135 @@
+@extends('admin.layouts.master')
+
+@section('title', 'ملف الطالب - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'ملف الطالب')
+    @section('page-subtitle', 'عرض تفاصيل الطالب وبيانات ولي الأمر')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('students.index') }}">الطلاب</a></li>
+        <li class="breadcrumb-item active">{{ $student->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm text-center">
+                <div class="card-body">
+                    <img src="{{ $student->avatar_url }}" class="rounded-circle mb-3" width="120" height="120" alt="{{ $student->name }}">
+                    <h4 class="mb-1">{{ $student->name }}</h4>
+                    <p class="text-muted mb-2" dir="ltr">{{ $student->username }}</p>
+                    <div class="mb-3">
+                        <span class="badge {{ $student->active ? 'bg-success' : 'bg-danger' }}">{{ $student->active ? 'نشط' : 'موقوف' }}</span>
+                    </div>
+                    <div class="d-grid gap-2">
+                        @can('edit_students')
+                            <a href="{{ route('students.edit', $student) }}" class="btn btn-outline-primary">
+                                <i class="fas fa-edit"></i> تعديل البيانات
+                            </a>
+                        @endcan
+                        @can('delete_students')
+                            <form action="{{ route('students.destroy', $student) }}" method="POST" onsubmit="return confirm('هل تريد حذف الطالب؟');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-danger">
+                                    <i class="fas fa-trash"></i> حذف الطالب
+                                </button>
+                            </form>
+                        @endcan
+                    </div>
+                </div>
+                <div class="card-footer text-muted" dir="ltr">
+                    آخر تحديث {{ $student->updated_at->diffForHumans() }}
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">المعلومات الأكاديمية</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label class="text-muted">الصف الدراسي</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->grade_level ?? 'غير محدد' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">الفصل</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->classroom ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">تاريخ الالتحاق</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->formatted_enrollment_date ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">الرقم التعريفي</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->student_code ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">تاريخ الميلاد</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->formatted_birth_date ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">الجنس</label>
+                            <div class="fw-semibold">
+                                @switch($student->studentProfile?->gender)
+                                    @case('male') ذكر @break
+                                    @case('female') أنثى @break
+                                    @default غير محدد
+                                @endswitch
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">بيانات التواصل</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="text-muted">البريد الإلكتروني</label>
+                            <div class="fw-semibold" dir="ltr">{{ $student->email ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="text-muted">رقم الهاتف</label>
+                            <div class="fw-semibold" dir="ltr">{{ $student->phone ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="text-muted">العنوان</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->address ?? '—' }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">بيانات ولي الأمر</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="text-muted">اسم ولي الأمر</label>
+                            <div class="fw-semibold">{{ $student->studentProfile?->guardian_name ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="text-muted">هاتف ولي الأمر</label>
+                            <div class="fw-semibold" dir="ltr">{{ $student->studentProfile?->guardian_phone ?? '—' }}</div>
+                        </div>
+                        <div class="col-12">
+                            <label class="text-muted">ملاحظات</label>
+                            <div>{{ $student->studentProfile?->notes ?? 'لا توجد ملاحظات' }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/modules/Students/Routes/web.php
+++ b/modules/Students/Routes/web.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+use Modules\Students\Http\Controllers\StudentController;
+
+Route::middleware(['web', 'auth'])->group(function () {
+    Route::bind('student', function ($value) {
+        return User::role('student')->with('studentProfile')->findOrFail($value);
+    });
+
+    Route::prefix('students')->name('students.')->group(function () {
+        Route::get('/', [StudentController::class, 'index'])
+            ->name('index')
+            ->middleware('can:view_students');
+
+        Route::get('/create', [StudentController::class, 'create'])
+            ->name('create')
+            ->middleware('can:create_students');
+
+        Route::post('/', [StudentController::class, 'store'])
+            ->name('store')
+            ->middleware('can:create_students');
+
+        Route::get('/export', [StudentController::class, 'export'])
+            ->name('export')
+            ->middleware('can:export_students');
+
+        Route::get('/reports', [StudentController::class, 'reports'])
+            ->name('reports')
+            ->middleware('can:view_students');
+
+        Route::get('/{student}', [StudentController::class, 'show'])
+            ->name('show')
+            ->middleware('can:view_students');
+
+        Route::get('/{student}/edit', [StudentController::class, 'edit'])
+            ->name('edit')
+            ->middleware('can:edit_students');
+
+        Route::put('/{student}', [StudentController::class, 'update'])
+            ->name('update')
+            ->middleware('can:edit_students');
+
+        Route::delete('/{student}', [StudentController::class, 'destroy'])
+            ->name('destroy')
+            ->middleware('can:delete_students');
+    });
+});

--- a/modules/Students/module.json
+++ b/modules/Students/module.json
@@ -1,0 +1,10 @@
+{
+    "name": "Students",
+    "alias": "students",
+    "description": "إدارة بيانات الطلاب ومتابعة ملفاتهم الأكاديمية.",
+    "keywords": ["students", "enrollment", "guardians"],
+    "priority": 5,
+    "providers": [
+        "Modules\\Students\\Providers\\StudentsServiceProvider"
+    ]
+}

--- a/modules/Teachers/Http/Controllers/TeacherController.php
+++ b/modules/Teachers/Http/Controllers/TeacherController.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace Modules\Teachers\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\TeacherProfile;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
+use Modules\Teachers\Http\Requests\StoreTeacherRequest;
+use Modules\Teachers\Http\Requests\UpdateTeacherRequest;
+
+class TeacherController extends Controller
+{
+    /**
+     * Display a listing of teachers.
+     */
+    public function index(Request $request): View
+    {
+        $filters = $this->filters($request);
+        $teachers = $this->filteredTeachers($filters);
+
+        $stats = [
+            'total' => User::role('teacher')->count(),
+            'active' => User::role('teacher')->where('active', true)->count(),
+            'inactive' => User::role('teacher')->where('active', false)->count(),
+            'with_subjects' => TeacherProfile::whereNotNull('subjects')->count(),
+        ];
+
+        return view('teachers::index', [
+            'teachers' => $teachers,
+            'filters' => $filters,
+            'stats' => $stats,
+            'specializations' => $this->specializationOptions(),
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new teacher.
+     */
+    public function create(): View
+    {
+        return view('teachers::create', [
+            'specializations' => $this->specializationOptions(),
+        ]);
+    }
+
+    /**
+     * Store a newly created teacher.
+     */
+    public function store(StoreTeacherRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $avatarPath = $this->handleAvatarUpload($request);
+
+        $teacher = User::create([
+            'name' => $data['name'],
+            'username' => $data['username'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'password' => Hash::make($data['password']),
+            'avatar' => $avatarPath,
+            'active' => $request->boolean('active', true),
+        ]);
+
+        $teacher->assignRole('teacher');
+
+        $teacher->teacherProfile()->create($this->profilePayload($data));
+
+        return redirect()
+            ->route('teachers.show', $teacher)
+            ->with('success', 'تم إضافة المعلم بنجاح.');
+    }
+
+    /**
+     * Display the specified teacher.
+     */
+    public function show(User $teacher): View
+    {
+        $teacher->load('teacherProfile');
+
+        return view('teachers::show', [
+            'teacher' => $teacher,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified teacher.
+     */
+    public function edit(User $teacher): View
+    {
+        $teacher->load('teacherProfile');
+
+        return view('teachers::edit', [
+            'teacher' => $teacher,
+            'specializations' => $this->specializationOptions(),
+        ]);
+    }
+
+    /**
+     * Update the specified teacher.
+     */
+    public function update(UpdateTeacherRequest $request, User $teacher): RedirectResponse
+    {
+        $data = $request->validated();
+        $payload = [
+            'name' => $data['name'],
+            'username' => $data['username'],
+            'email' => $data['email'] ?? null,
+            'phone' => $data['phone'] ?? null,
+            'active' => $request->boolean('active', true),
+        ];
+
+        if (! empty($data['password'])) {
+            $payload['password'] = Hash::make($data['password']);
+        }
+
+        $avatarPath = $this->handleAvatarUpload($request, $teacher);
+        if ($avatarPath !== null) {
+            $payload['avatar'] = $avatarPath;
+        }
+
+        $teacher->update($payload);
+        $teacher->teacherProfile()->updateOrCreate([], $this->profilePayload($data));
+
+        return redirect()
+            ->route('teachers.show', $teacher)
+            ->with('success', 'تم تحديث بيانات المعلم بنجاح.');
+    }
+
+    /**
+     * Remove the specified teacher.
+     */
+    public function destroy(User $teacher): RedirectResponse
+    {
+        if ($teacher->is(auth()->user())) {
+            return redirect()
+                ->route('teachers.index')
+                ->with('error', 'لا يمكنك حذف حسابك الشخصي.');
+        }
+
+        $this->deleteAvatarIfExists($teacher);
+        $teacher->delete();
+
+        return redirect()
+            ->route('teachers.index')
+            ->with('success', 'تم حذف المعلم بنجاح.');
+    }
+
+    /**
+     * Display teachers schedules summary.
+     */
+    public function schedules(): View
+    {
+        $teachers = User::role('teacher')
+            ->with('teacherProfile')
+            ->whereHas('teacherProfile')
+            ->orderBy('name')
+            ->get();
+
+        $bySpecialization = $teachers->groupBy(fn (User $teacher) => $teacher->teacherProfile?->specialization ?? 'غير محدد')
+            ->map->count();
+
+        $subjectsCloud = $teachers->flatMap(function (User $teacher) {
+            return collect($teacher->teacherProfile?->subjects ?? []);
+        })->filter()->countBy()->sortDesc();
+
+        return view('teachers::schedules', compact('teachers', 'bySpecialization', 'subjectsCloud'));
+    }
+
+    /**
+     * Retrieve filtered teachers.
+     */
+    protected function filteredTeachers(array $filters)
+    {
+        $query = User::query()
+            ->role('teacher')
+            ->with('teacherProfile');
+
+        if (! empty($filters['search'])) {
+            $query->where(function ($q) use ($filters) {
+                $q->where('name', 'like', "%{$filters['search']}%")
+                    ->orWhere('email', 'like', "%{$filters['search']}%")
+                    ->orWhere('username', 'like', "%{$filters['search']}%")
+                    ->orWhere('phone', 'like', "%{$filters['search']}%")
+                    ->orWhereHas('teacherProfile', function ($sub) use ($filters) {
+                        $sub->where('teacher_code', 'like', "%{$filters['search']}%")
+                            ->orWhere('specialization', 'like', "%{$filters['search']}%")
+                            ->orWhere('qualification', 'like', "%{$filters['search']}%");
+                    });
+            });
+        }
+
+        if (! empty($filters['specialization'])) {
+            $query->whereHas('teacherProfile', function ($q) use ($filters) {
+                $q->where('specialization', $filters['specialization']);
+            });
+        }
+
+        if (! empty($filters['gender'])) {
+            $query->whereHas('teacherProfile', function ($q) use ($filters) {
+                $q->where('gender', $filters['gender']);
+            });
+        }
+
+        if ($filters['status'] !== null) {
+            $query->where('active', (bool) $filters['status']);
+        }
+
+        return $query->orderBy('name')->paginate(12)->withQueryString();
+    }
+
+    /**
+     * Extract filters from request.
+     */
+    protected function filters(Request $request): array
+    {
+        $status = match ($request->input('status')) {
+            'active' => 1,
+            'inactive' => 0,
+            default => null,
+        };
+
+        return [
+            'search' => $request->input('search'),
+            'specialization' => $request->input('specialization'),
+            'gender' => $request->input('gender'),
+            'status' => $status,
+        ];
+    }
+
+    /**
+     * Prepare profile payload.
+     */
+    protected function profilePayload(array $data): array
+    {
+        $payload = Arr::only($data, [
+            'teacher_code',
+            'gender',
+            'specialization',
+            'qualification',
+            'hire_date',
+            'experience_years',
+            'phone_secondary',
+            'address',
+            'office_hours',
+            'notes',
+        ]);
+
+        $payload['subjects'] = $this->subjectsArray($data['subjects'] ?? null);
+
+        return $payload;
+    }
+
+    /**
+     * Convert subjects string to array.
+     */
+    protected function subjectsArray(?string $subjects): array
+    {
+        return collect(explode(',', $subjects ?? ''))
+            ->map(fn ($subject) => trim($subject))
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Handle avatar upload.
+     */
+    protected function handleAvatarUpload(Request $request, ?User $teacher = null): ?string
+    {
+        if (! $request->hasFile('avatar')) {
+            return $teacher?->avatar;
+        }
+
+        $path = $request->file('avatar')->store('avatars', 'public');
+
+        if ($teacher && $teacher->avatar) {
+            Storage::disk('public')->delete($teacher->avatar);
+        }
+
+        return $path;
+    }
+
+    /**
+     * Delete stored avatar if exists.
+     */
+    protected function deleteAvatarIfExists(User $teacher): void
+    {
+        if ($teacher->avatar) {
+            Storage::disk('public')->delete($teacher->avatar);
+        }
+    }
+
+    /**
+     * Specialization options list.
+     */
+    protected function specializationOptions(): array
+    {
+        return [
+            'اللغة العربية',
+            'اللغة الإنجليزية',
+            'الرياضيات',
+            'العلوم',
+            'الدراسات الاجتماعية',
+            'الحاسب الآلي',
+            'اللغة الفرنسية',
+            'اللغة الألمانية',
+            'التربية الرياضية',
+            'التربية الفنية',
+            'التربية الدينية',
+            'الموسيقى',
+        ];
+    }
+}

--- a/modules/Teachers/Http/Requests/StoreTeacherRequest.php
+++ b/modules/Teachers/Http/Requests/StoreTeacherRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Modules\Teachers\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTeacherRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create_teachers') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:255', 'unique:users,username'],
+            'email' => ['nullable', 'email', 'max:255', 'unique:users,email'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'active' => ['sometimes', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
+            'teacher_code' => ['nullable', 'string', 'max:50', 'unique:teacher_profiles,teacher_code'],
+            'gender' => ['nullable', 'in:male,female'],
+            'specialization' => ['nullable', 'string', 'max:150'],
+            'qualification' => ['nullable', 'string', 'max:150'],
+            'hire_date' => ['nullable', 'date', 'before_or_equal:today'],
+            'experience_years' => ['nullable', 'integer', 'min:0', 'max:60'],
+            'phone_secondary' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'subjects' => ['nullable', 'string', 'max:255'],
+            'office_hours' => ['nullable', 'string', 'max:120'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'name' => 'اسم المعلم',
+            'username' => 'اسم المستخدم',
+            'email' => 'البريد الإلكتروني',
+            'phone' => 'رقم الهاتف',
+            'password' => 'كلمة المرور',
+            'teacher_code' => 'الرقم الوظيفي',
+            'gender' => 'النوع',
+            'specialization' => 'التخصص',
+            'qualification' => 'المؤهل العلمي',
+            'hire_date' => 'تاريخ التعيين',
+            'experience_years' => 'سنوات الخبرة',
+            'phone_secondary' => 'هاتف إضافي',
+            'address' => 'العنوان',
+            'subjects' => 'المواد الدراسية',
+            'office_hours' => 'ساعات التواجد',
+            'notes' => 'الملاحظات',
+        ];
+    }
+}

--- a/modules/Teachers/Http/Requests/UpdateTeacherRequest.php
+++ b/modules/Teachers/Http/Requests/UpdateTeacherRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Modules\Teachers\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateTeacherRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('edit_teachers') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        $teacherId = $this->route('teacher')?->getKey();
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:255', Rule::unique('users', 'username')->ignore($teacherId)],
+            'email' => ['nullable', 'email', 'max:255', Rule::unique('users', 'email')->ignore($teacherId)],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'active' => ['sometimes', 'boolean'],
+            'avatar' => ['nullable', 'image', 'max:2048'],
+            'teacher_code' => ['nullable', 'string', 'max:50', Rule::unique('teacher_profiles', 'teacher_code')->ignore($teacherId, 'user_id')],
+            'gender' => ['nullable', 'in:male,female'],
+            'specialization' => ['nullable', 'string', 'max:150'],
+            'qualification' => ['nullable', 'string', 'max:150'],
+            'hire_date' => ['nullable', 'date', 'before_or_equal:today'],
+            'experience_years' => ['nullable', 'integer', 'min:0', 'max:60'],
+            'phone_secondary' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'subjects' => ['nullable', 'string', 'max:255'],
+            'office_hours' => ['nullable', 'string', 'max:120'],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return (new StoreTeacherRequest())->attributes();
+    }
+}

--- a/modules/Teachers/Providers/TeachersServiceProvider.php
+++ b/modules/Teachers/Providers/TeachersServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Teachers\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class TeachersServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $moduleBasePath = __DIR__ . '/../';
+
+        $this->loadRoutesFrom($moduleBasePath . 'Routes/web.php');
+        $this->loadViewsFrom($moduleBasePath . 'Resources/views', 'teachers');
+    }
+}

--- a/modules/Teachers/Resources/views/create.blade.php
+++ b/modules/Teachers/Resources/views/create.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.master')
+
+@section('title', 'إضافة معلم جديد - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إضافة معلم جديد')
+    @section('page-subtitle', 'تسجيل بيانات معلم في النظام')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('teachers.index') }}">المعلمين</a></li>
+        <li class="breadcrumb-item active">إضافة معلم</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h5 class="card-title mb-4">بيانات المعلم</h5>
+            <form method="POST" action="{{ route('teachers.store') }}" enctype="multipart/form-data">
+                @csrf
+                @include('teachers::partials.form')
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('teachers.index') }}" class="btn btn-light">إلغاء</a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save"></i> حفظ البيانات
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/modules/Teachers/Resources/views/edit.blade.php
+++ b/modules/Teachers/Resources/views/edit.blade.php
@@ -1,0 +1,34 @@
+@extends('admin.layouts.master')
+
+@section('title', 'تعديل بيانات المعلم - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'تعديل بيانات المعلم')
+    @section('page-subtitle', 'تحديث بيانات المعلم الوظيفية والتواصل')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('teachers.index') }}">المعلمين</a></li>
+        <li class="breadcrumb-item active">{{ $teacher->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <h5 class="card-title mb-4">بيانات المعلم</h5>
+            <form method="POST" action="{{ route('teachers.update', $teacher) }}" enctype="multipart/form-data">
+                @csrf
+                @method('PUT')
+                @include('teachers::partials.form')
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('teachers.show', $teacher) }}" class="btn btn-light">إلغاء</a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-save"></i> تحديث البيانات
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/modules/Teachers/Resources/views/index.blade.php
+++ b/modules/Teachers/Resources/views/index.blade.php
@@ -1,0 +1,196 @@
+@extends('admin.layouts.master')
+
+@section('title', 'المعلمين - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'إدارة المعلمين')
+    @section('page-subtitle', 'متابعة بيانات المعلمين وجداولهم')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item active">المعلمين</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4 mb-4">
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon teachers"><i class="fas fa-chalkboard-teacher"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ $stats['total'] }}</div>
+                    <div class="stat-label">إجمالي المعلمين</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-check"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-success">{{ $stats['active'] }}</div>
+                    <div class="stat-label">معلمون نشطون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon attendance"><i class="fas fa-user-slash"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number text-danger">{{ $stats['inactive'] }}</div>
+                    <div class="stat-label">معلمون موقوفون</div>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="stat-card shadow-sm">
+                <div class="stat-card-header">
+                    <div class="stat-icon classes"><i class="fas fa-book-open"></i></div>
+                </div>
+                <div class="stat-content">
+                    <div class="stat-number">{{ $stats['with_subjects'] }}</div>
+                    <div class="stat-label">معلمون محددة موادهم</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
+                <h5 class="mb-0"><i class="fas fa-filter me-2"></i> تصفية المعلمين</h5>
+                <div class="d-flex gap-2">
+                    <a href="{{ route('teachers.schedules') }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-calendar-alt"></i> عرض الجداول
+                    </a>
+                    @can('create_teachers')
+                        <a href="{{ route('teachers.create') }}" class="btn btn-primary">
+                            <i class="fas fa-user-plus"></i> معلم جديد
+                        </a>
+                    @endcan
+                </div>
+            </div>
+
+            <form method="GET" action="{{ route('teachers.index') }}" class="row g-3">
+                <div class="col-md-4">
+                    <label class="form-label">بحث</label>
+                    <input type="text" name="search" value="{{ $filters['search'] }}" class="form-control" placeholder="ابحث بالاسم أو التخصص أو البريد">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">التخصص</label>
+                    <select name="specialization" class="form-select">
+                        <option value="">الكل</option>
+                        @foreach($specializations as $specialization)
+                            <option value="{{ $specialization }}" @selected($filters['specialization'] === $specialization)>{{ $specialization }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">الجنس</label>
+                    <select name="gender" class="form-select">
+                        <option value="">الكل</option>
+                        <option value="male" @selected($filters['gender'] === 'male')>ذكر</option>
+                        <option value="female" @selected($filters['gender'] === 'female')>أنثى</option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label">الحالة</label>
+                    <select name="status" class="form-select">
+                        <option value="">الكل</option>
+                        <option value="active" @selected(request('status') === 'active')>نشط</option>
+                        <option value="inactive" @selected(request('status') === 'inactive')>موقوف</option>
+                    </select>
+                </div>
+                <div class="col-12 d-flex justify-content-end gap-2">
+                    <a href="{{ route('teachers.index') }}" class="btn btn-outline-secondary">
+                        <i class="fas fa-rotate-left"></i> إعادة تعيين
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-search"></i> عرض النتائج
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>المعلم</th>
+                            <th>التخصص</th>
+                            <th>المواد الدراسية</th>
+                            <th>الهاتف</th>
+                            <th>تاريخ التعيين</th>
+                            <th class="text-center">الحالة</th>
+                            <th class="text-center">إجراءات</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($teachers as $teacher)
+                            @php($profile = $teacher->teacherProfile)
+                            <tr>
+                                <td>
+                                    <div class="d-flex align-items-center gap-3">
+                                        <img src="{{ $teacher->avatar_url }}" alt="{{ $teacher->name }}" class="rounded-circle" width="42" height="42">
+                                        <div>
+                                            <div class="fw-semibold">{{ $teacher->name }}</div>
+                                            <small class="text-muted" dir="ltr">{{ $teacher->username }}</small>
+                                        </div>
+                                    </div>
+                                </td>
+                                <td>
+                                    <span class="badge bg-info-subtle text-info">{{ $profile?->specialization ?? 'غير محدد' }}</span>
+                                    <div class="text-muted small">{{ $profile?->qualification ?? '—' }}</div>
+                                </td>
+                                <td>{{ $profile?->subjects_list ?? '—' }}</td>
+                                <td dir="ltr">{{ $teacher->phone ?? '—' }}</td>
+                                <td>{{ $profile?->formatted_hire_date ?? '—' }}</td>
+                                <td class="text-center">
+                                    <span class="badge {{ $teacher->active ? 'bg-success' : 'bg-danger' }}">{{ $teacher->active ? 'نشط' : 'موقوف' }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <div class="btn-group" role="group">
+                                        @can('view_teachers')
+                                            <a href="{{ route('teachers.show', $teacher) }}" class="btn btn-sm btn-outline-primary" title="عرض">
+                                                <i class="fas fa-eye"></i>
+                                            </a>
+                                        @endcan
+                                        @can('edit_teachers')
+                                            <a href="{{ route('teachers.edit', $teacher) }}" class="btn btn-sm btn-outline-secondary" title="تعديل">
+                                                <i class="fas fa-edit"></i>
+                                            </a>
+                                        @endcan
+                                        @can('delete_teachers')
+                                            <form action="{{ route('teachers.destroy', $teacher) }}" method="POST" onsubmit="return confirm('هل أنت متأكد من حذف المعلم؟');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="حذف">
+                                                    <i class="fas fa-trash"></i>
+                                                </button>
+                                            </form>
+                                        @endcan
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center py-4 text-muted">لا توجد بيانات لعرضها.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="card-footer d-flex justify-content-end">
+            {{ $teachers->withQueryString()->links() }}
+        </div>
+    </div>
+@endsection

--- a/modules/Teachers/Resources/views/partials/form.blade.php
+++ b/modules/Teachers/Resources/views/partials/form.blade.php
@@ -1,0 +1,98 @@
+@php($editing = isset($teacher))
+
+<div class="row g-3">
+    <div class="col-md-5">
+        <label class="form-label">اسم المعلم</label>
+        <input type="text" name="name" value="{{ old('name', $editing ? $teacher->name : '') }}" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">اسم المستخدم</label>
+        <input type="text" name="username" value="{{ old('username', $editing ? $teacher->username : '') }}" class="form-control" required>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">الرقم الوظيفي</label>
+        <input type="text" name="teacher_code" value="{{ old('teacher_code', $editing ? optional($teacher->teacherProfile)->teacher_code : '') }}" class="form-control">
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">حالة الحساب</label>
+        <select name="active" class="form-select">
+            <option value="1" @selected(old('active', $editing ? $teacher->active : true))>نشط</option>
+            <option value="0" @selected(old('active', $editing ? ! $teacher->active : false))>موقوف</option>
+        </select>
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">البريد الإلكتروني</label>
+        <input type="email" name="email" value="{{ old('email', $editing ? $teacher->email : '') }}" class="form-control">
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">رقم الهاتف</label>
+        <input type="text" name="phone" value="{{ old('phone', $editing ? $teacher->phone : '') }}" class="form-control">
+    </div>
+    <div class="col-md-3">
+        <label class="form-label">هاتف إضافي</label>
+        <input type="text" name="phone_secondary" value="{{ old('phone_secondary', optional($teacher->teacherProfile ?? null)->phone_secondary) }}" class="form-control">
+    </div>
+
+    <div class="col-md-6">
+        <label class="form-label">كلمة المرور</label>
+        <input type="password" name="password" class="form-control" @if(! $editing) required @endif placeholder="{{ $editing ? 'اتركها فارغة للحفاظ على الحالية' : '' }}">
+    </div>
+    <div class="col-md-6">
+        <label class="form-label">تأكيد كلمة المرور</label>
+        <input type="password" name="password_confirmation" class="form-control" @if(! $editing) required @endif>
+    </div>
+
+    <div class="col-md-4">
+        <label class="form-label">التخصص</label>
+        <select name="specialization" class="form-select">
+            <option value="">اختر التخصص</option>
+            @foreach($specializations as $specialization)
+                <option value="{{ $specialization }}" @selected(old('specialization', optional($teacher->teacherProfile ?? null)->specialization) === $specialization)>{{ $specialization }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">المؤهل العلمي</label>
+        <input type="text" name="qualification" value="{{ old('qualification', optional($teacher->teacherProfile ?? null)->qualification) }}" class="form-control">
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">النوع</label>
+        <select name="gender" class="form-select">
+            <option value="">غير محدد</option>
+            <option value="male" @selected(old('gender', optional($teacher->teacherProfile ?? null)->gender) === 'male')>ذكر</option>
+            <option value="female" @selected(old('gender', optional($teacher->teacherProfile ?? null)->gender) === 'female')>أنثى</option>
+        </select>
+    </div>
+    <div class="col-md-2">
+        <label class="form-label">سنوات الخبرة</label>
+        <input type="number" name="experience_years" value="{{ old('experience_years', optional($teacher->teacherProfile ?? null)->experience_years) }}" class="form-control" min="0" max="60">
+    </div>
+
+    <div class="col-md-3">
+        <label class="form-label">تاريخ التعيين</label>
+        <input type="date" name="hire_date" value="{{ old('hire_date', optional(optional($teacher->teacherProfile ?? null)->hire_date)->format('Y-m-d')) }}" class="form-control">
+    </div>
+    <div class="col-md-5">
+        <label class="form-label">المواد الدراسية</label>
+        <input type="text" name="subjects" value="{{ old('subjects', collect(optional($teacher->teacherProfile ?? null)->subjects)->implode(', ')) }}" class="form-control" placeholder="اكتب المواد مفصولة بفاصلة">
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">ساعات التواجد</label>
+        <input type="text" name="office_hours" value="{{ old('office_hours', optional($teacher->teacherProfile ?? null)->office_hours) }}" class="form-control" placeholder="مثال: الأحد-الخميس 8ص-2م">
+    </div>
+
+    <div class="col-md-8">
+        <label class="form-label">العنوان</label>
+        <input type="text" name="address" value="{{ old('address', optional($teacher->teacherProfile ?? null)->address) }}" class="form-control">
+    </div>
+    <div class="col-md-4">
+        <label class="form-label">صورة المعلم</label>
+        <input type="file" name="avatar" class="form-control">
+    </div>
+
+    <div class="col-12">
+        <label class="form-label">ملاحظات</label>
+        <textarea name="notes" rows="3" class="form-control">{{ old('notes', optional($teacher->teacherProfile ?? null)->notes) }}</textarea>
+    </div>
+</div>

--- a/modules/Teachers/Resources/views/schedules.blade.php
+++ b/modules/Teachers/Resources/views/schedules.blade.php
@@ -1,0 +1,98 @@
+@extends('admin.layouts.master')
+
+@section('title', 'جداول المعلمين - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'جداول المعلمين')
+    @section('page-subtitle', 'نظرة شاملة على توزيع الحصص وساعات التواجد')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('teachers.index') }}">المعلمين</a></li>
+        <li class="breadcrumb-item active">الجداول</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">توزيع المعلمين حسب التخصص</h5>
+                </div>
+                <div class="card-body">
+                    @if($bySpecialization->isEmpty())
+                        <p class="text-muted mb-0">لا توجد بيانات لعرضها.</p>
+                    @else
+                        <ul class="list-group list-group-flush">
+                            @foreach($bySpecialization as $specialization => $count)
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    <span>{{ $specialization }}</span>
+                                    <span class="badge bg-primary rounded-pill">{{ $count }}</span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-white d-flex justify-content-between align-items-center">
+                    <h5 class="card-title mb-0">شعبية المواد الدراسية</h5>
+                    <span class="badge bg-info">{{ $subjectsCloud->sum() }} مادة</span>
+                </div>
+                <div class="card-body">
+                    @if($subjectsCloud->isEmpty())
+                        <p class="text-muted mb-0">لم يتم تحديد مواد للمعلمين بعد.</p>
+                    @else
+                        <div class="d-flex flex-wrap gap-2">
+                            @foreach($subjectsCloud as $subject => $count)
+                                <span class="badge bg-light text-dark border">{{ $subject }} <span class="text-muted">({{ $count }})</span></span>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mt-4">
+        <div class="card-header bg-white d-flex justify-content-between align-items-center">
+            <h5 class="card-title mb-0">ساعات التواجد وجدول الحصص</h5>
+            <a href="{{ route('teachers.index') }}" class="btn btn-sm btn-outline-secondary">
+                <i class="fas fa-arrow-right"></i> الرجوع لقائمة المعلمين
+            </a>
+        </div>
+        <div class="card-body">
+            @if($teachers->isEmpty())
+                <p class="text-muted mb-0">لا توجد بيانات متاحة حالياً.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle">
+                        <thead>
+                            <tr>
+                                <th>المعلم</th>
+                                <th>التخصص</th>
+                                <th>المواد</th>
+                                <th>ساعات التواجد</th>
+                                <th>رقم التواصل</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($teachers as $teacher)
+                                <tr>
+                                    <td>{{ $teacher->name }}</td>
+                                    <td>{{ $teacher->teacherProfile?->specialization ?? '—' }}</td>
+                                    <td>{{ $teacher->teacherProfile?->subjects_list ?? '—' }}</td>
+                                    <td>{{ $teacher->teacherProfile?->office_hours ?? '—' }}</td>
+                                    <td dir="ltr">{{ $teacher->phone ?? '—' }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/modules/Teachers/Resources/views/show.blade.php
+++ b/modules/Teachers/Resources/views/show.blade.php
@@ -1,0 +1,125 @@
+@extends('admin.layouts.master')
+
+@section('title', 'ملف المعلم - نظام مدرسة بلقاس')
+
+@section('page-header')
+    @section('page-title', 'ملف المعلم')
+    @section('page-subtitle', 'عرض تفاصيل المعلم وسجله الوظيفي')
+
+    @section('breadcrumb')
+        <li class="breadcrumb-item"><a href="{{ route('dashboard') }}">لوحة التحكم</a></li>
+        <li class="breadcrumb-item"><a href="{{ route('teachers.index') }}">المعلمين</a></li>
+        <li class="breadcrumb-item active">{{ $teacher->name }}</li>
+    @endsection
+@endsection
+
+@section('content')
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm text-center">
+                <div class="card-body">
+                    <img src="{{ $teacher->avatar_url }}" class="rounded-circle mb-3" width="120" height="120" alt="{{ $teacher->name }}">
+                    <h4 class="mb-1">{{ $teacher->name }}</h4>
+                    <p class="text-muted mb-2" dir="ltr">{{ $teacher->username }}</p>
+                    <span class="badge {{ $teacher->active ? 'bg-success' : 'bg-danger' }}">{{ $teacher->active ? 'نشط' : 'موقوف' }}</span>
+                    <div class="mt-3 text-start">
+                        <div class="mb-2"><strong>التخصص:</strong> {{ $teacher->teacherProfile?->specialization ?? 'غير محدد' }}</div>
+                        <div class="mb-2"><strong>المؤهل:</strong> {{ $teacher->teacherProfile?->qualification ?? '—' }}</div>
+                        <div class="mb-2"><strong>المواد:</strong> {{ $teacher->teacherProfile?->subjects_list ?? '—' }}</div>
+                    </div>
+                    <div class="d-grid gap-2 mt-3">
+                        @can('edit_teachers')
+                            <a href="{{ route('teachers.edit', $teacher) }}" class="btn btn-outline-primary">
+                                <i class="fas fa-edit"></i> تعديل البيانات
+                            </a>
+                        @endcan
+                        @can('delete_teachers')
+                            <form action="{{ route('teachers.destroy', $teacher) }}" method="POST" onsubmit="return confirm('هل تريد حذف المعلم؟');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-danger">
+                                    <i class="fas fa-trash"></i> حذف المعلم
+                                </button>
+                            </form>
+                        @endcan
+                    </div>
+                </div>
+                <div class="card-footer text-muted" dir="ltr">
+                    آخر تحديث {{ $teacher->updated_at->diffForHumans() }}
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-8">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">البيانات الوظيفية</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label class="text-muted">الرقم الوظيفي</label>
+                            <div class="fw-semibold">{{ $teacher->teacherProfile?->teacher_code ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">تاريخ التعيين</label>
+                            <div class="fw-semibold">{{ $teacher->teacherProfile?->formatted_hire_date ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">سنوات الخبرة</label>
+                            <div class="fw-semibold">{{ $teacher->teacherProfile?->experience_years ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">ساعات التواجد</label>
+                            <div class="fw-semibold">{{ $teacher->teacherProfile?->office_hours ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="text-muted">النوع</label>
+                            <div class="fw-semibold">
+                                @switch($teacher->teacherProfile?->gender)
+                                    @case('male') ذكر @break
+                                    @case('female') أنثى @break
+                                    @default غير محدد
+                                @endswitch
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">بيانات التواصل</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="text-muted">البريد الإلكتروني</label>
+                            <div class="fw-semibold" dir="ltr">{{ $teacher->email ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="text-muted">رقم الهاتف</label>
+                            <div class="fw-semibold" dir="ltr">{{ $teacher->phone ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="text-muted">هاتف إضافي</label>
+                            <div class="fw-semibold" dir="ltr">{{ $teacher->teacherProfile?->phone_secondary ?? '—' }}</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="text-muted">العنوان</label>
+                            <div class="fw-semibold">{{ $teacher->teacherProfile?->address ?? '—' }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow-sm">
+                <div class="card-header bg-white">
+                    <h5 class="card-title mb-0">ملاحظات إضافية</h5>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">{{ $teacher->teacherProfile?->notes ?? 'لا توجد ملاحظات.' }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/modules/Teachers/Routes/web.php
+++ b/modules/Teachers/Routes/web.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+use Modules\Teachers\Http\Controllers\TeacherController;
+
+Route::middleware(['web', 'auth'])->group(function () {
+    Route::bind('teacher', function ($value) {
+        return User::role('teacher')->with('teacherProfile')->findOrFail($value);
+    });
+
+    Route::prefix('teachers')->name('teachers.')->group(function () {
+        Route::get('/', [TeacherController::class, 'index'])
+            ->name('index')
+            ->middleware('can:view_teachers');
+
+        Route::get('/create', [TeacherController::class, 'create'])
+            ->name('create')
+            ->middleware('can:create_teachers');
+
+        Route::post('/', [TeacherController::class, 'store'])
+            ->name('store')
+            ->middleware('can:create_teachers');
+
+        Route::get('/schedules', [TeacherController::class, 'schedules'])
+            ->name('schedules')
+            ->middleware('can:view_teachers');
+
+        Route::get('/{teacher}', [TeacherController::class, 'show'])
+            ->name('show')
+            ->middleware('can:view_teachers');
+
+        Route::get('/{teacher}/edit', [TeacherController::class, 'edit'])
+            ->name('edit')
+            ->middleware('can:edit_teachers');
+
+        Route::put('/{teacher}', [TeacherController::class, 'update'])
+            ->name('update')
+            ->middleware('can:edit_teachers');
+
+        Route::delete('/{teacher}', [TeacherController::class, 'destroy'])
+            ->name('destroy')
+            ->middleware('can:delete_teachers');
+    });
+});

--- a/modules/Teachers/module.json
+++ b/modules/Teachers/module.json
@@ -1,0 +1,10 @@
+{
+    "name": "Teachers",
+    "alias": "teachers",
+    "description": "إدارة سجلات المعلمين والبيانات الوظيفية.",
+    "keywords": ["teachers", "staff", "schedules"],
+    "priority": 6,
+    "providers": [
+        "Modules\\Teachers\\Providers\\TeachersServiceProvider"
+    ]
+}

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,3 +1,5 @@
 {
-    "Users": true
+    "Users": true,
+    "Students": true,
+    "Teachers": true
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,24 +18,6 @@ Route::middleware(['auth'])->group(function () {
     // Main Dashboard
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
-    // Students Routes
-    Route::prefix('students')->name('students.')->group(function () {
-        Route::get('/', function() { return view('students.index'); })->name('index')->middleware('can:view_students');
-        Route::get('/create', function() { return view('students.create'); })->name('create')->middleware('can:create_students');
-        Route::get('/{student}', function() { return view('students.show'); })->name('show')->middleware('can:view_students');
-        Route::get('/{student}/edit', function() { return view('students.edit'); })->name('edit')->middleware('can:edit_students');
-        Route::get('/reports', function() { return view('students.reports'); })->name('reports')->middleware('can:view_students');
-    });
-
-    // Teachers Routes
-    Route::prefix('teachers')->name('teachers.')->group(function () {
-        Route::get('/', function() { return view('teachers.index'); })->name('index')->middleware('can:view_teachers');
-        Route::get('/create', function() { return view('teachers.create'); })->name('create')->middleware('can:create_teachers');
-        Route::get('/{teacher}', function() { return view('teachers.show'); })->name('show')->middleware('can:view_teachers');
-        Route::get('/{teacher}/edit', function() { return view('teachers.edit'); })->name('edit')->middleware('can:edit_teachers');
-        Route::get('/schedules', function() { return view('teachers.schedules'); })->name('schedules')->middleware('can:view_teachers');
-    });
-
     // Classes Routes
     Route::prefix('classes')->name('classes.')->group(function () {
         Route::get('/', function() { return view('classes.index'); })->name('index')->middleware('can:view_classes');


### PR DESCRIPTION
## Summary
- add student and teacher profile models with dedicated migrations and link them to users
- implement a full students module with CRUD, filtering, reporting, export and blade screens
- deliver a teachers module covering CRUD operations, schedules overview, and update default seed data and module registry

## Testing
- `php artisan test` *(fails: vendor directory not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4b9a66b4832fbc3514efb5e7c200