### PR TITLE
Load module providers from module definition

### DIFF
--- a/app/Providers/ModuleServiceProvider.php
+++ b/app/Providers/ModuleServiceProvider.php
@@ -26,10 +26,25 @@ class ModuleServiceProvider extends ServiceProvider
                 continue;
             }
 
-            $serviceProvider = sprintf('Modules\\%s\\Providers\\%sServiceProvider', $moduleName, $moduleName);
+            $moduleDefinitionPath = $moduleDirectory . DIRECTORY_SEPARATOR . 'module.json';
 
-            if (class_exists($serviceProvider)) {
-                $this->app->register($serviceProvider);
+            if (! File::exists($moduleDefinitionPath)) {
+                continue;
+            }
+
+            $moduleDefinition = json_decode(File::get($moduleDefinitionPath), true) ?: [];
+            $providers = $moduleDefinition['providers'] ?? [];
+
+            if (! is_array($providers)) {
+                continue;
+            }
+
+            foreach ($providers as $provider) {
+                if (! is_string($provider) || ! class_exists($provider)) {
+                    continue;
+                }
+
+                $this->app->register($provider);
             }
         }
     }


### PR DESCRIPTION
## Summary
- read module definitions to retrieve provider class lists for enabled modules
- register each configured provider when the class exists so module services bootstrap correctly

## Testing
- php artisan route:clear *(fails: missing vendor/autoload.php in container)*
- php artisan config:clear *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc206c8f4832f8e9e3f007802ca3c